### PR TITLE
Increase speedup quality

### DIFF
--- a/custom_components/chime_tts/__init__.py
+++ b/custom_components/chime_tts/__init__.py
@@ -552,7 +552,7 @@ async def async_request_tts_audio(hass: HomeAssistant,
                     _LOGGER.debug("  -  ...changing TTS playback speed to %s percent",
                                 str(tts_playback_speed))
                     playback_speed = float(tts_playback_speed / 100)
-                    audio = audio.speedup(playback_speed=playback_speed)
+                    audio = audio.speedup(playback_speed=playback_speed, chunk_size=50)
                 end_time = datetime.now()
                 _LOGGER.debug(" - ...TTS audio completed in %s ms",
                             str((end_time - start_time).total_seconds() * 1000))


### PR DESCRIPTION
At the moment the speedup quality is not good, which makes the TTS hard to understand. The chunk_size is chosen quite big (or rather long) by pydub to preserve all frequencies above 20Hz - but such low frequencies don't matter at all with TTS. Therefore I could simply set the chunk_size from 150 to 50 and thereby increase the quality and intelligibility significantly.

Here are some examples before and after. I had to upload them as videos because github doesn't allow audio (you have to enable sound on each player).

150% sounds mostly mediocre and occasionally swallows letters. Here it sounds like "test" instead of "text"

https://github.com/nimroddolev/chime_tts/assets/30938717/adebedff-4979-4c64-b8cd-06fc630b1770


https://github.com/nimroddolev/chime_tts/assets/30938717/6efe2170-844a-4a73-8566-4f77c97aaa81

200% sounds absolutely unusable before - but afterwards well understandable

https://github.com/nimroddolev/chime_tts/assets/30938717/efbc9f07-8b07-4bf7-96bd-b0313be9bd24


https://github.com/nimroddolev/chime_tts/assets/30938717/a7aa7d61-6373-44d4-873c-7e765c503e9c


