### PR TITLE
Add language support for Amazon Polly

### DIFF
--- a/custom_components/chime_tts/__init__.py
+++ b/custom_components/chime_tts/__init__.py
@@ -507,6 +507,7 @@ async def async_request_tts_audio(
 
     # Language
     if (language or tts_options.get("language")) and tts_platform in [
+        AMAZON_POLLY,
         GOOGLE_TRANSLATE,
         NABU_CASA_CLOUD_TTS,
         IBM_WATSON_TTS,

--- a/custom_components/chime_tts/services.yaml
+++ b/custom_components/chime_tts/services.yaml
@@ -248,8 +248,7 @@ say:
             value: Custom
           translation_key: audio_conversion
     language:
-      description: The TTS language (supported by Google Translate, Microsoft Edge
-        TTS and Nabu Casa Cloud TTS)
+      description: The TTS language (supported by Google Translate, Microsoft Edge TTS, Amazon Polly and Nabu Casa Cloud TTS)
       example: en
       name: Language
       required: false


### PR DESCRIPTION
Amazon Polly supports (and needs) `language` for non-English