### PR TITLE
Fix external address resolution

### DIFF
--- a/custom_components/chime_tts/helpers/filesystem.py
+++ b/custom_components/chime_tts/helpers/filesystem.py
@@ -334,7 +334,7 @@ class FilesystemHelper:
         """External address of the Home Assistant instance."""
         instance_url = hass.config.external_url
         if instance_url is None:
-            instance_url = str(get_url(hass))
+            instance_url = str(get_url(hass, prefer_external=True))
         if instance_url and instance_url.endswith("/"):
             instance_url = instance_url[:-1]
         return instance_url
@@ -462,9 +462,7 @@ class FilesystemHelper:
             return
 
         # Convert external URL to local filepath
-        instance_url = hass.config.external_url
-        if instance_url is None:
-            instance_url = str(get_url(hass))
+        instance_url = self.get_external_address(hass)
         if f"{file_path}".startswith(instance_url):
             file_path = (
                 file_path
@@ -487,9 +485,12 @@ class FilesystemHelper:
         if file_path.startswith("/config"):
             return file_path
 
-        instance_url = f"{hass.config.external_url}"
-        if instance_url is None:
-            instance_url = f"{str(get_url(hass))}"
+        instance_url = self.get_external_address(hass)
+        if not instance_url:
+            _LOGGER.error("Failed to determine the instance URL.")
+            return file_path
+
+        instance_url = f"{instance_url}"
         if instance_url.endswith("/"):
             instance_url = instance_url[:-1]
         public_dir = hass.config.path('www')


### PR DESCRIPTION
[Issue Ref](https://github.com/nimroddolev/chime_tts/issues/234)

### Changes:
- In `__init__.py` updated sync/async method invocation to match signatures.
- In `filesystem.py` update `get_external_address` to apply prefer_external=True to avoid the default behavior and resolve an internal url. [Doc ref for default behavior](https://developers.home-assistant.io/docs/instance_url/#default-behavior)
  - Also switch other uses of get_url attempting to resolve external_address to use the same helper method.


**Disclaimer:** I'm not a python dev :) so while I tested it in my env, not sure about best practises/conventions. Feel free to close/update the PR as needed.