### PR TITLE
Fix downloadable chimes to work with .oga and application/octet-stream

### DIFF
--- a/custom_components/chime_tts/helpers/filesystem.py
+++ b/custom_components/chime_tts/helpers/filesystem.py
@@ -31,7 +31,7 @@ from .media_player_helper import MediaPlayerHelper
 media_player_helper = MediaPlayerHelper()
 
 _LOGGER = logging.getLogger(__name__)
-_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.flac', '.aac', '.ogg', '.wma', '.m4a', '.aiff', '.aif', '.ape']
+_AUDIO_EXTENSIONS = ['.mp3', '.wav', '.flac', '.aac', '.ogg', '.wma', '.m4a', '.aiff', '.aif', '.ape', '.oga']
 
 class FilesystemHelper:
     """Filesystem helper functions for Chime TTS."""
@@ -253,7 +253,7 @@ class FilesystemHelper:
             return None
 
         content_type = response.headers.get('Content-Type', '')
-        if 'audio' in content_type:
+        if 'audio' in content_type or 'octet-stream' in content_type:
             _LOGGER.debug("Audio downloaded successfully")
             _, file_extension = os.path.splitext(url)
             try:


### PR DESCRIPTION
Telegram API provides voice messages with `.oga` audio extension, and HTTP header 'Content-Type' is set to '`application/octet-stream`'. This prevented chime_tts from downloading these audio files with these lines in log:

```
2025-07-13 02:00:33.844 DEBUG (MainThread) [custom_components.chime_tts.helpers.filesystem] External chime not found in cache
2025-07-13 02:00:33.844 DEBUG (MainThread) [custom_components.chime_tts.helpers.filesystem] Downloading chime at URL: https://api.telegram.org/file/botREDACTED:REDACTED/voice/file_302.oga
2025-07-13 02:00:34.045 WARNING (MainThread) [custom_components.chime_tts.helpers.filesystem] Unable to extract audio from URL with content-type 'application/octet-stream'
2025-07-13 02:00:34.045 WARNING (MainThread) [custom_components.chime_tts.helpers.filesystem] Unable to downloaded chime from URL: https://api.telegram.org/file/botREDACTED:REDACTED/voice/file_302.oga
2025-07-13 02:00:34.046 WARNING (MainThread) [custom_components.chime_tts] Unable to generate local audio filepath
2025-07-13 02:00:34.048 ERROR (SyncWorker_1) [custom_components.chime_tts] async_get_playback_audio_path --> Audio has no duration
2025-07-13 02:00:34.048 ERROR (SyncWorker_1) [custom_components.chime_tts] async_get_playback_audio_path --> Unable to generate local audio file
2025-07-13 02:00:34.048 ERROR (SyncWorker_1) [custom_components.chime_tts] async_get_playback_audio_path --> Unable to generate Media Content Id
```

I've added `octet-stream` to `Content-Type` header check, as some misconfigured servers serve downloadable files with this header.