### PR TITLE
Fix: Prevent volume spikes on Google Cast devices during playback

### DIFF
--- a/custom_components/chime_tts/helpers/media_player_helper.py
+++ b/custom_components/chime_tts/helpers/media_player_helper.py
@@ -3,6 +3,7 @@
 import logging
 import time
 import math
+import asyncio
 from homeassistant.core import HomeAssistant, State
 from homeassistant.const import CONF_ENTITY_ID, SERVICE_VOLUME_SET
 from .media_player import ChimeTTSMediaPlayer
@@ -515,6 +516,14 @@ class MediaPlayerHelper:
             entity_id: str = media_player.entity_id
             current_volume: float = media_player.get_current_volume_level()
             target_volume: float = getattr(media_player, volume_key, 0) if isinstance(volume_key, str) else volume_key
+
+            if (media_player.platform == "cast" and 
+                media_player.get_state() == "playing" and 
+                target_volume > current_volume):
+                
+                _LOGGER.debug("Preventing Google Cast volume spike for %s", entity_id)
+                await hass.services.async_call("media_player", "media_stop", {CONF_ENTITY_ID: entity_id})
+                await asyncio.sleep(0.05)
 
             if target_volume == -1:
                 if volume_key == "initial_volume_level":


### PR DESCRIPTION
**Description**:
This PR addresses a common issue where Google Cast devices (like Nest Mini/Hub) experience a brief volume "spike" of the current media before playing a Chime TTS notification.

**The Problem**:
When a target volume is set and the Cast device is currently playing media, the volume_set command often executes while the previous stream's buffer is still active. This results in a fraction of a second where the previous media is heard at the new (often higher) notification volume.

**The Solution**:
For cast platform devices, this change introduces a proactive media_stop followed by a minimal asynchronous delay (50ms) before the volume is adjusted. This ensures the media pipeline is cleared before the volume level changes, providing a seamless transition to the chime/notification.

**Changes**:
  - Modified async_set_volume_for_media_players in media_player_helper.py.
  - Added a check for media_player.platform == "cast".
  - Introduced await asyncio.sleep(0.05) to allow the Cast device to process the stop command before adjusting volume.
  - Used non-blocking service call for media_stop to maintain performance.

**Testing**:
  - Tested on Nest Mini (2nd Gen) while playing radio stream and tidal cast.
  - Confirmed that the volume spike is eliminated without any noticeable delay in notification delivery.