### PR TITLE
Fix playback, TTS selection, and caching on current Home Assistant; add tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,82 @@
+name: "Tests"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  test:
+    name: "pytest (${{ matrix.label }})"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Oldest supported pair: newest HA that still runs on Python 3.12.
+          - label: "py3.12 / HA 2025.1"
+            python-version: "3.12"
+            phccc: "pytest-homeassistant-custom-component==0.13.190"
+          # A mid HA release on 3.13.
+          - label: "py3.13 / HA mid"
+            python-version: "3.13"
+            phccc: "pytest-homeassistant-custom-component==0.13.200"
+          # Latest HA needs Python 3.14: recent pytest-homeassistant-custom-component
+          # releases declare requires-python >=3.14, so on 3.13 pip backtracks to an
+          # older release and this row would not exercise the latest HA API.
+          - label: "py3.14 / HA latest"
+            python-version: "3.14"
+            phccc: "pytest-homeassistant-custom-component"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "${{ matrix.python-version }}"
+          cache: "pip"
+
+      - name: "Install ffmpeg"
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: "Install dependencies"
+        run: |
+          python -m pip install --upgrade pip
+          pip install pydub aiofiles mutagen ha-ffmpeg "${{ matrix.phccc }}"
+
+      - name: "Run tests"
+        run: pytest tests/ --cov=custom_components/chime_tts --cov-report=term-missing
+
+  lint:
+    name: "Ruff + mypy"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: "Set up Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.13"
+          cache: "pip"
+      - name: "Install"
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff==0.8.4 mypy pytest-homeassistant-custom-component
+      # ruff check and mypy currently report pre-existing violations in the
+      # integration source (untyped code, invalid escape sequences). They run
+      # but do not gate yet; flip continue-on-error off as that debt is paid
+      # down. Format check is already clean and gates now.
+      - name: "Ruff check"
+        run: ruff check custom_components/chime_tts tests
+        continue-on-error: true
+      # The integration source predates ruff's formatter; format-check only the
+      # new test code for now and expand coverage as source files are reformatted.
+      - name: "Ruff format"
+        run: ruff format --check tests
+      - name: "mypy"
+        run: mypy custom_components/chime_tts
+        continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__
 htmlcov
 
 # virtualenvs
-.venv
+.venv*
 venv
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@ __pycache__
 *.egg-info
 */build/*
 */dist/*
+.tox
+.mypy_cache
+.ruff_cache
+htmlcov
+
+# virtualenvs
+.venv
+venv
 
 
 # misc

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -41,6 +41,10 @@ lint.ignore = [
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 
+[lint.per-file-ignores]
+# Test functions are self-documenting by name; docstrings are not required.
+"tests/**" = ["D100", "D101", "D102", "D103", "D104"]
+
 # [tool.ruff.pyupgrade]
 # keep-runtime-typing = true
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+# chime_tts developer tasks. Run inside the test venv:
+#   python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements_test.txt
+
+PKG := custom_components/chime_tts
+HA_HOST ?=
+HA_PORT ?= 22
+HA_USER ?= root
+HA_PATH ?= /config/custom_components/chime_tts
+
+.PHONY: help install lint format format-fix typecheck test test-strict cov matrix deploy-restart clean
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN{FS=":.*?# "}{printf "  %-16s %s\n", $$1, $$2}'
+
+install: # install the test/lint/type stack into the active venv
+	pip install -r requirements_test.txt
+
+lint: # ruff lint
+	ruff check $(PKG) tests
+
+format: # check formatting only
+	ruff format --check $(PKG) tests
+
+format-fix: # apply formatting
+	ruff format $(PKG) tests
+
+typecheck: # mypy
+	mypy $(PKG)
+
+test: # run tests with a coverage report
+	pytest tests/ --cov=$(PKG) --cov-report=term-missing
+
+test-strict: # tests + 80% coverage gate (pre-PR)
+	pytest tests/ --cov=$(PKG) --cov-report=term-missing --cov-fail-under=80
+
+cov: # html coverage report
+	pytest tests/ --cov=$(PKG) --cov-report=html && echo "open htmlcov/index.html"
+
+matrix: # run the full HA version matrix (tox)
+	tox
+
+deploy-restart: # rsync the integration to a live HA host and restart it
+	@test -n "$(HA_HOST)" || { echo "set HA_HOST=<ip>"; exit 1; }
+	rsync -az --delete -e "ssh -p $(HA_PORT)" \
+		$(PKG)/ $(HA_USER)@$(HA_HOST):$(HA_PATH)/
+	ssh -p $(HA_PORT) $(HA_USER)@$(HA_HOST) 'ha core restart'
+
+clean:
+	rm -rf .pytest_cache .mypy_cache .ruff_cache htmlcov .coverage .tox

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # chime_tts developer tasks. Run inside the test venv:
 #   python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements_test.txt
+#
+# To test against the latest Home Assistant (which needs Python 3.13/3.14), use
+# `make venv-latest` and activate .venv314. Latest HA is the primary target.
 
 PKG := custom_components/chime_tts
 HA_HOST ?=
@@ -7,7 +10,7 @@ HA_PORT ?= 22
 HA_USER ?= root
 HA_PATH ?= /config/custom_components/chime_tts
 
-.PHONY: help install lint format format-fix typecheck test test-strict cov matrix deploy-restart clean
+.PHONY: help install venv-latest lint format format-fix typecheck test test-strict cov matrix deploy-restart clean
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?# .*$$' $(MAKEFILE_LIST) | \
@@ -15,6 +18,13 @@ help:
 
 install: # install the test/lint/type stack into the active venv
 	pip install -r requirements_test.txt
+
+venv-latest: # build .venv314 (Python 3.14) with the latest Home Assistant for testing
+	# Latest HA (2026.6.x) declares requires-python >=3.14.2, so 3.14 is required
+	# here; 3.13 resolves to an older HA and would not test the current release.
+	uv venv --python 3.14 .venv314
+	. .venv314/bin/activate && uv pip install -r requirements_test.txt
+	@echo "Activate with: . .venv314/bin/activate"
 
 lint: # ruff lint
 	ruff check $(PKG) tests

--- a/custom_components/chime_tts/__init__.py
+++ b/custom_components/chime_tts/__init__.py
@@ -710,7 +710,7 @@ async def async_verify_cached_audio(hass: HomeAssistant,
 
         # Test if cached audio file exists on the filesystem
         local_exists = await hass.async_add_executor_job(filesystem_helper.path_exists, f"{audio_dict.get(LOCAL_PATH_KEY, '')}")
-        local_external_filepath = filesystem_helper.get_local_path(hass=hass, file_path=f"{audio_dict.get(PUBLIC_PATH_KEY, '')}")
+        local_external_filepath = await filesystem_helper.async_get_local_path(hass=hass, file_path=f"{audio_dict.get(PUBLIC_PATH_KEY, '')}")
         public_exists = await hass.async_add_executor_job(filesystem_helper.path_exists, local_external_filepath) or f"{audio_dict.get(PUBLIC_PATH_KEY, '')}".startswith("http://localhost")
 
         if not (public_exists or local_exists):
@@ -1448,8 +1448,8 @@ async def async_add_audio_file_to_cache(hass: HomeAssistant,
         audio_cache_dict = await async_get_cached_audio_data(hass, filepath_hash)
         if not audio_cache_dict:
             audio_cache_dict = {}
-        local_audio_path = filesystem_helper.get_local_path(hass=hass, file_path=audio_path)
-        if local_audio_path.startswith((_data[WWW_PATH_KEY], "http")):
+        local_audio_path = await filesystem_helper.async_get_local_path(hass=hass, file_path=audio_path)
+        if local_audio_path and local_audio_path.startswith((_data[WWW_PATH_KEY], "http")):
             audio_cache_dict[PUBLIC_PATH_KEY] = audio_path
         else:
             audio_cache_dict[LOCAL_PATH_KEY] = audio_path

--- a/custom_components/chime_tts/__init__.py
+++ b/custom_components/chime_tts/__init__.py
@@ -695,6 +695,16 @@ def validate_audio_dict(hass: HomeAssistant, is_local: bool, is_public: bool, au
                 is_valid = False
     return is_valid
 
+def _should_reapply_conversion_on_cache_hit(ffmpeg_args: str, is_alexa_compatible: bool) -> bool:
+    """Whether a cached file needs re-conversion on a cache hit.
+
+    The audio conversion is part of the cache key, so a cached file was already
+    converted when generated; re-applying it compounds the effect (#282, #280).
+    The only case that still needs work is back-filling a legacy Alexa entry that
+    predates the Alexa-compatibility conversion.
+    """
+    return ffmpeg_args == FFMPEG_ARGS_ALEXA and not is_alexa_compatible
+
 async def async_verify_cached_audio(hass: HomeAssistant,
                                     filepath_hash: str,
                                     params: dict,
@@ -751,12 +761,15 @@ async def async_verify_cached_audio(hass: HomeAssistant,
                                                                                      f"{audio_dict.get(LOCAL_PATH_KEY, '')}" or
                                                                                      f"{audio_dict.get(PUBLIC_PATH_KEY, '')}")
 
-        # Apply audio conversion
-        if (local_exists or public_exists) and ffmpeg_args:
+        # A cached file already has its conversion baked in (the conversion is
+        # part of the cache key), so it is not re-applied here. Only a legacy
+        # Alexa entry needs work: back-fill the compatibility conversion (#282, #280).
+        if (local_exists or public_exists) and ffmpeg_args == FFMPEG_ARGS_ALEXA:
             for local_path in [audio_dict.get(LOCAL_PATH_KEY), local_external_filepath]:
                 if local_path and await hass.async_add_executor_job(filesystem_helper.path_exists, local_path):
-                    if not (ffmpeg_args == FFMPEG_ARGS_ALEXA and await filesystem_helper.async_is_audio_alexa_compatible(hass, local_path)):
-                        _LOGGER.debug("   Apply audio conversion")
+                    is_alexa_compatible = await filesystem_helper.async_is_audio_alexa_compatible(hass, local_path)
+                    if _should_reapply_conversion_on_cache_hit(ffmpeg_args, is_alexa_compatible):
+                        _LOGGER.debug("   Back-filling Alexa-compatible conversion for cached file")
                         await helpers.async_ffmpeg_convert_from_file(hass, local_path, ffmpeg_args)
                     elif local_path == local_external_filepath:
                         _LOGGER.debug("Cached file already Alexa Media Player compatible: '%s'", local_path)
@@ -1472,6 +1485,10 @@ def get_filename_hash_from_service_data(params: dict, options: dict):
         "language",
         "chime_path",
         "audio_conversion",
+        # The parsed conversion lives under "ffmpeg_args" in the params dict.
+        # Include it so a cache entry is unique per conversion; without this,
+        # different conversions collide on one cached file (#282, #280).
+        "ffmpeg_args",
         "end_chime_path",
         "offset",
         "crossfade",

--- a/custom_components/chime_tts/__init__.py
+++ b/custom_components/chime_tts/__init__.py
@@ -274,6 +274,19 @@ async def async_setup(hass: HomeAssistant, _config_entry: ConfigEntry) -> bool: 
 
     return True
 
+async def async_run_script(hass: HomeAssistant, script):
+    """Run a script entity before or after playback, if one is configured (#310)."""
+    if not script:
+        return
+    domain, _, name = str(script).strip().partition(".")
+    if domain != "script" or not name:
+        _LOGGER.warning("chime_tts: '%s' is not a script entity (expected script.<name>)", script)
+        return
+    try:
+        await hass.services.async_call("script", name, blocking=True)
+    except Exception as error:
+        _LOGGER.warning("chime_tts: error running script '%s': %s", script, error)
+
 async def async_prepare_media(hass: HomeAssistant, params, options, media_players_array: list[ChimeTTSMediaPlayer], is_say_url, start_time):
     """Prepare and play media."""
 
@@ -292,6 +305,9 @@ async def async_prepare_media(hass: HomeAssistant, params, options, media_player
 
         if is_say_url is False:
 
+            # Optional script to run before playback (#310)
+            await async_run_script(hass, params.get("pre_script"))
+
             # Play audio with service_data
             play_result = await async_play_media(
                 hass,
@@ -306,6 +322,9 @@ async def async_prepare_media(hass: HomeAssistant, params, options, media_player
                     params["final_delay"],
                     media_players_array,
                 )
+
+            # Optional script to run after playback (#310)
+            await async_run_script(hass, params.get("post_script"))
 
             # Remove temporary local generated mp3
             if not bool(params.get("cache", False)):
@@ -616,6 +635,14 @@ async def async_get_playback_audio_path(params: dict, options: dict):
             raise ValueError("The file format is not supported or the file is corrupted.")
         except Exception as e:
             raise RuntimeError(f"An unexpected error occurred: {e}")
+
+        # Repeat the whole assembled chime + message audio (#314). Done at the
+        # audio level so the chimes repeat too, not just the message segments.
+        repeat = params.get("repeat", 1)
+        repeat = max(repeat, 1) if isinstance(repeat, int) else 1
+        if repeat > 1:
+            new_audio_segment = new_audio_segment * repeat
+            await filesystem_helper.async_export_audio(new_audio_segment, new_audio_file)
 
         duration = len(new_audio_segment) / 1000.0
         audio_dict[AUDIO_DURATION_KEY] = duration
@@ -1494,7 +1521,8 @@ def get_filename_hash_from_service_data(params: dict, options: dict):
         "crossfade",
         "tts_playback_speed",
         "tts_speed",
-        "tts_pitch"
+        "tts_pitch",
+        "repeat",
     ]
     for param in relevant_params:
         for dictionary in [params, options]:

--- a/custom_components/chime_tts/__init__.py
+++ b/custom_components/chime_tts/__init__.py
@@ -1061,6 +1061,24 @@ async def async_play_media(
 
     return play_result
 
+def _sonos_volume_set_call(entity_id, volume_percent: int):
+    """Build an explicit volume_set call for Sonos before an announcement.
+
+    Some Sonos models ignore the announce `extra.volume`, so the volume is set
+    directly first; the snapshot/restore around the announcement returns the
+    previous level (#275, #256).
+    """
+    return {
+        "domain": "media_player",
+        "service": "volume_set",
+        "service_data": {
+            CONF_ENTITY_ID: entity_id,
+            "volume_level": round(max(0, min(100, volume_percent)) / 100, 2),
+        },
+        "blocking": True,
+        "result": True,
+    }
+
 async def async_prepare_media_service_calls(hass: HomeAssistant, entity_ids, service_data, audio_dict):
     """Prepare the media_player service calls for audio playback."""
     helpers.debug_subtitle("Chime TTS playback")
@@ -1122,12 +1140,21 @@ async def async_prepare_media_service_calls(hass: HomeAssistant, entity_ids, ser
             for entity_id in sonos_media_player_entity_ids:
                 _LOGGER.debug("     - %s", entity_id)
 
-            # If all media_players have same target volume level
-            uniform_target_volume = int(media_player_helper.get_uniform_target_volume_level(sonos_media_player_entity_ids) * 100)
-            if uniform_target_volume != -1:
+            # If all media_players have same target volume level. Check the -1
+            # "not uniform" sentinel on the raw level before scaling to a
+            # percentage, otherwise it becomes -100 and the per-player branch
+            # below never runs.
+            uniform_level = media_player_helper.get_uniform_target_volume_level(sonos_media_player_entity_ids)
+            if uniform_level != -1:
+                uniform_target_volume = int(uniform_level * 100)
                 sonos_service_data[CONF_ENTITY_ID] = sonos_media_player_entity_ids
                 if uniform_target_volume >= 0:
                     sonos_service_data["extra"] = {"volume": uniform_target_volume}
+                    # Set the volume explicitly only when the Sonos snapshot/restore
+                    # is enabled to return it afterwards; without restore the announce
+                    # volume would persist (#275, #256).
+                    if SONOS_SNAPSHOT_ENABLED:
+                        service_calls.append(_sonos_volume_set_call(sonos_media_player_entity_ids, uniform_target_volume))
                 service_calls.append({
                     "domain": "media_player",
                     "service": SERVICE_PLAY_MEDIA,
@@ -1143,6 +1170,8 @@ async def async_prepare_media_service_calls(hass: HomeAssistant, entity_ids, ser
                     individual_service_data[CONF_ENTITY_ID] = media_player.entity_id
                     if volume >= 0:
                         individual_service_data["extra"] = {"volume": volume}
+                        if SONOS_SNAPSHOT_ENABLED:
+                            service_calls.append(_sonos_volume_set_call(media_player.entity_id, volume))
                     service_calls.append({
                         "domain": "media_player",
                         "service": SERVICE_PLAY_MEDIA,

--- a/custom_components/chime_tts/config_flow.py
+++ b/custom_components/chime_tts/config_flow.py
@@ -221,7 +221,13 @@ class ChimeTTSOptionsFlowHandler(config_entries.OptionsFlow):
             if os.path.commonpath([parent_dir]) == os.path.commonpath([parent_dir, sub_dir]):
                 temp_folder_in_media_dir = True
         if not temp_folder_in_media_dir:
-            _errors[TEMP_PATH_KEY] = TEMP_PATH_KEY
+            # Accept the default media/www roots even when not listed in
+            # media_dirs, mirroring the www-path check below, so the default
+            # temp path does not error on a standard install (#306).
+            temp_path: str = user_input.get(TEMP_PATH_KEY, "")
+            if not (temp_path.startswith(f"{root_path}/media/")
+                    or temp_path.startswith(f"{root_path}/config/www/")):
+                _errors[TEMP_PATH_KEY] = TEMP_PATH_KEY
         ###
 
         # `chime_tts.say_url` folder must be subfolder of an external directory

--- a/custom_components/chime_tts/helpers/filesystem.py
+++ b/custom_components/chime_tts/helpers/filesystem.py
@@ -385,8 +385,8 @@ class FilesystemHelper:
         """
         try:
             # Validate file path
-            file_path = self.get_local_path(hass=hass, file_path=file_path)
-            if not (os.path.isfile(file_path) and await hass.async_add_executor_job(self.path_exists, file_path)):
+            file_path = await self.async_get_local_path(hass=hass, file_path=file_path)
+            if not file_path or not await hass.async_add_executor_job(os.path.isfile, file_path):
                 _LOGGER.debug("Unable to convert audio. File not found: %s", file_path)
                 return False
 
@@ -509,6 +509,15 @@ class FilesystemHelper:
                 _LOGGER.debug("Local file path for external URL is '%s'", local_file_path)
             return local_file_path
         return None
+
+    async def async_get_local_path(self, hass: HomeAssistant, file_path: str = ""):
+        """Async wrapper for get_local_path.
+
+        get_local_path runs blocking filesystem checks (path_exists, which can
+        call os.listdir, and os.path.isfile). Calling it on the event loop is a
+        blocking-call violation (#318, #258), so offload it to an executor.
+        """
+        return await hass.async_add_executor_job(self.get_local_path, hass, file_path)
 
     def get_hash_for_string(self, string):
         """Generate a has for a given string."""

--- a/custom_components/chime_tts/helpers/helpers.py
+++ b/custom_components/chime_tts/helpers/helpers.py
@@ -738,22 +738,22 @@ class ChimeTTSHelper:
         """Debug log a title string."""
         if len(title) == 0:
             return
-        _LOGGER.debug(f"╔{"═"*(int(len(title) + 2))}╗")
+        _LOGGER.debug(f"╔{'═'*(int(len(title) + 2))}╗")
         _LOGGER.debug(f"║ {title} ║")
-        _LOGGER.debug(f"╚{"═"*(int(len(title) + 2))}╝")
+        _LOGGER.debug(f"╚{'═'*(int(len(title) + 2))}╝")
 
     def debug_subtitle(self, title: str = ""):
         """Debug log a subtitle string."""
         if len(title) == 0:
             return
-        _LOGGER.debug(f"╭{"─"*(int(len(title) + 2))}╮")
+        _LOGGER.debug(f"╭{'─'*(int(len(title) + 2))}╮")
         _LOGGER.debug(f"│ {title} │")
-        _LOGGER.debug(f"╰{"─"*(int(len(title) + 2))}╯")
+        _LOGGER.debug(f"╰{'─'*(int(len(title) + 2))}╯")
 
     def debug_finish(self, title: str = ""):
         """Debug log a subtitle string."""
         if len(title) == 0:
             return
-        _LOGGER.debug(f"╭{"─"*(int(len(title) + 5))}─────╮")
+        _LOGGER.debug(f"╭{'─'*(int(len(title) + 5))}─────╮")
         _LOGGER.debug(f"│──── {title} ────│")
-        _LOGGER.debug(f"╰{"─"*(int(len(title) + 5))}─────╯")
+        _LOGGER.debug(f"╰{'─'*(int(len(title) + 5))}─────╯")

--- a/custom_components/chime_tts/helpers/helpers.py
+++ b/custom_components/chime_tts/helpers/helpers.py
@@ -340,7 +340,6 @@ class ChimeTTSHelper:
 
         installed_tts_platforms: list[str] = self.get_installed_tts_platforms(hass)
 
-        selected_platform = None
         # No TTS platform provided
         if not tts_platform:
             tts_platform = default_tts_platform if default_tts_platform else fallback_tts_platform
@@ -349,26 +348,62 @@ class ChimeTTSHelper:
         if tts_platform.lower() == NABU_CASA_CLOUD_TTS_OLD:
             tts_platform = NABU_CASA_CLOUD_TTS
 
-        # Match for installed tts platform
-        if tts_platform.lower() in installed_tts_platforms:
-            selected_platform = tts_platform.lower()            
-        elif tts_platform.find("google") != -1:
-            # Return alternate Google Translate entity, eg: "tts.google_en_com"
-            if tts_platform.startswith("tts."):
-                for installed_tts_platform in installed_tts_platforms:
-                    if (installed_tts_platform.lower().find("google") != -1
-                        and installed_tts_platform.startswith("tts.")):
-                        _LOGGER.warning("The TTS entity '%s' was not found. Using '%s' instead.", tts_platform, installed_tts_platform)
-                        selected_platform = installed_tts_platform
-            # Return Google Translate, if installed
-            if GOOGLE_TRANSLATE in installed_tts_platforms:
-                _LOGGER.warning("The TTS platform '%s' was not found. Using '%s' instead.", tts_platform, GOOGLE_TRANSLATE)
-                return GOOGLE_TRANSLATE
+        selected_platform = self._match_tts_platform(tts_platform, installed_tts_platforms)
+        if selected_platform is None:
+            selected_platform = self._match_google_fallback(tts_platform, installed_tts_platforms)
 
-        _LOGGER.debug("Selected TTS platform: %s", selected_platform)
         if selected_platform is None:
             _LOGGER.warning("Unable to select a TTS platform - installed TTS platforms: %s", installed_tts_platforms)
+        else:
+            _LOGGER.debug("Selected TTS platform: %s", selected_platform)
         return selected_platform
+
+    @staticmethod
+    def _match_tts_platform(requested: str, installed: list[str]):
+        """Match a requested platform against the installed list.
+
+        Handles both forms used across HA versions and the user's config: a full
+        entity id (``tts.piper``) and a bare provider name (``piper``). Earlier
+        code truncated entity ids to their first token, so multi-word providers
+        such as ``tts.google_generative_ai`` never matched (#291, #308, #241).
+        """
+        if not requested:
+            return None
+        target = requested.lower()
+        bare = target[4:] if target.startswith("tts.") else target
+        # Exact match on a provider name or full entity id.
+        for inst in installed:
+            il = inst.lower()
+            if il == target or il == bare or il == f"tts.{bare}":
+                return inst
+        # A bare provider name maps to its entity (tts.<bare>_<suffix>), but only
+        # when unambiguous. A broad name like "google" prefixes several distinct
+        # providers (translate, generative_ai); leave those to the fallback.
+        prefix = f"tts.{bare}_"
+        suffix_matches = [inst for inst in installed if inst.lower().startswith(prefix)]
+        if len(suffix_matches) == 1:
+            return suffix_matches[0]
+        return None
+
+    def _match_google_fallback(self, requested: str, installed: list[str]):
+        """Last-resort fallback for an unmatched Google request.
+
+        Only reached when no platform matched, so a genuine provider like
+        ``tts.google_generative_ai`` is selected by its exact id first and is
+        never diverted here.
+        """
+        if not requested or requested.lower().find("google") == -1:
+            return None
+        # Prefer an installed Google entity that is not generative AI.
+        for inst in installed:
+            il = inst.lower()
+            if il.startswith("tts.") and "google" in il and "generative" not in il:
+                _LOGGER.warning("The TTS entity '%s' was not found. Using '%s' instead.", requested, inst)
+                return inst
+        if GOOGLE_TRANSLATE in installed:
+            _LOGGER.warning("The TTS platform '%s' was not found. Using '%s' instead.", requested, GOOGLE_TRANSLATE)
+            return GOOGLE_TRANSLATE
+        return None
 
 
     def get_stripped_tts_platform(self, tts_provider = ""):
@@ -411,48 +446,40 @@ class ChimeTTSHelper:
         return tts_provider
 
     def get_installed_tts_platforms(self, hass: HomeAssistant) -> list[str]:
-        """List of installed tts platforms."""
-        
-        # Try the new 2025.8+ method first
+        """Installed TTS platforms as full tts.* entity ids plus legacy names."""
+        platforms: list[str] = []
+
+        # 2025.8+: TTS providers are exposed as tts.* entities. Keep the full
+        # entity id; truncating it (tts.google_generative_ai -> google) is what
+        # broke platform matching for multi-word providers (#291, #308, #241).
         try:
-            # Check for TTS entities (most reliable method in 2025.8+)
-            tts_entities = []
-            all_entities = hass.states.async_all()
-            for entity in all_entities:
-                if str(entity.entity_id).startswith("tts."):
-                    platform_name = str(entity.entity_id).replace("tts.", "").split("_")[0]
-                    if platform_name not in tts_entities:
-                        tts_entities.append(platform_name)
-            
-            # Add common TTS platforms if they exist
-            known_platforms = ["google_translate", "cloud", "edge_tts", "openai_tts", "piper"]
-            for platform in known_platforms:
-                if platform not in tts_entities:
-                    # Check if service exists
-                    try:
-                        service_exists = hass.services.has_service("tts", f"{platform}_say")
-                        if service_exists and platform not in tts_entities:
-                            tts_entities.append(platform)
-                    except:
-                        pass
-            
-            if tts_entities:
-                return sorted(tts_entities)
-                
+            for entity in hass.states.async_all():
+                entity_id = str(entity.entity_id)
+                if entity_id.startswith("tts.") and entity_id not in platforms:
+                    platforms.append(entity_id)
         except Exception as e:
-            _LOGGER.debug("New TTS detection method failed: %s", e)
-        
-        # Fallback to old method for older HA versions
+            _LOGGER.debug("Entity-based TTS detection failed: %s", e)
+
+        # Legacy providers (HA < 2025.8) are keyed by provider name.
         try:
-            # Old method for HA < 2025.8
-            tts_providers = list((hass.data["tts_manager"].providers).keys())
-            return sorted(tts_providers)
+            manager = hass.data.get("tts_manager")
+            if manager is not None:
+                for provider in manager.providers:
+                    if provider not in platforms:
+                        platforms.append(provider)
         except Exception as e:
-            _LOGGER.debug("Legacy TTS detection method failed: %s", e)
-        
-        # Last resort - return common platforms
-        _LOGGER.warning("Could not detect TTS platforms, returning common defaults")
-        return ["google_translate", "cloud", "edge_tts"]
+            _LOGGER.debug("Legacy TTS detection failed: %s", e)
+
+        # Service-based providers (tts.<name>_say) without a discoverable entity.
+        for platform in ("google_translate", "cloud", "edge_tts", "openai_tts", "piper"):
+            if platform not in platforms and hass.services.has_service("tts", f"{platform}_say"):
+                platforms.append(platform)
+
+        if not platforms:
+            _LOGGER.warning("Could not detect any TTS platforms; returning common defaults")
+            platforms = ["google_translate", "cloud", "edge_tts"]
+
+        return sorted(platforms)
 
 
 

--- a/custom_components/chime_tts/helpers/helpers.py
+++ b/custom_components/chime_tts/helpers/helpers.py
@@ -545,8 +545,8 @@ class ChimeTTSHelper:
     async def async_ffmpeg_convert_from_file(self, hass: HomeAssistant, file_path: str, ffmpeg_args: str):
         """Convert audio file with FFmpeg and provided arguments."""
 
-        local_file_path = filesystem_helper.get_local_path(hass, file_path)
-        if not await hass.async_add_executor_job(filesystem_helper.filepath_exists_locally, hass, local_file_path):
+        local_file_path = await filesystem_helper.async_get_local_path(hass, file_path)
+        if not (local_file_path and await hass.async_add_executor_job(os.path.isfile, local_file_path)):
             _LOGGER.warning("Unable to perform FFmpeg conversion: source file not found on file system: %s", local_file_path)
             return False
 

--- a/custom_components/chime_tts/helpers/helpers.py
+++ b/custom_components/chime_tts/helpers/helpers.py
@@ -72,6 +72,12 @@ class ChimeTTSHelper:
         tts_platform = str(data.get("tts_platform", ""))
         tts_speed = float(data.get("tts_playback_speed", data.get("tts_speed", 100)) or 100)
         tts_pitch = data.get("tts_pitch", 0) or 0
+        try:
+            repeat = max(int(data.get("repeat", 1) or 1), 1)
+        except (ValueError, TypeError):
+            repeat = 1
+        pre_script = data.get("pre_script", None)
+        post_script = data.get("post_script", None)
         volume_level = data.get(ATTR_MEDIA_VOLUME_LEVEL, -1) or -1
         join_players = data.get("join_players", False) or False
         unjoin_players = data.get("unjoin_players", False) or False
@@ -104,6 +110,9 @@ class ChimeTTSHelper:
             "tts_platform": tts_platform,
             "tts_speed": tts_speed,
             "tts_pitch": tts_pitch,
+            "repeat": repeat,
+            "pre_script": pre_script,
+            "post_script": post_script,
             "announce": announce,
             "fade_audio": fade_audio,
             "volume_level": volume_level,

--- a/custom_components/chime_tts/helpers/media_player_helper.py
+++ b/custom_components/chime_tts/helpers/media_player_helper.py
@@ -228,25 +228,40 @@ class MediaPlayerHelper:
         return False
 
     def get_media_content_id(self, hass: HomeAssistant, file_path: str):
-        """Create the media content id for a local media directory file."""
+        """Create the media-source content id for a file inside a media directory."""
         if not file_path:
             _LOGGER.error("Audio file path missing in call to get_media_content_id")
             return None
 
-        media_source_path = file_path
+        if hass is None or hass.config is None:
+            return None
+        media_dirs = hass.config.media_dirs or {}
 
-        media_dir_key = ""
-        for name_i, path_i in hass.config.media_dirs.items():
-            if file_path.startswith(path_i) and len(media_dir_key) < len(path_i):
-                media_dir_key = name_i
-        if self.media_dirs_dict.get(media_dir_key, None):
-            path = self.media_dirs_dict.get(media_dir_key, None)
-            media_source_path = media_source_path[len(f"/{path}") :]
-            media_source_path = f"media-source://media_source/{media_dir_key}/{media_source_path}"
-            return media_source_path
+        # Pick the media directory whose path is the longest prefix of file_path,
+        # matching only on a path boundary so a dir like /media does not also claim
+        # a sibling such as /media-other. The previous code compared the directory
+        # NAME length against the PATH length and stripped len("/" + path), which
+        # selected the wrong directory and dropped a character from the relative
+        # path (#289, #253).
+        matched_name = ""
+        matched_path = ""
+        for name, path in media_dirs.items():
+            if not path:
+                continue
+            root = path.rstrip("/")
+            if (file_path == root or file_path.startswith(root + "/")) and len(root) > len(matched_path):
+                matched_name = name
+                matched_path = root
 
-        # Media file exists outside of a media folder
-        return None
+        if not matched_path:
+            _LOGGER.debug(
+                "File %s is not inside a registered media directory; no media content id",
+                file_path,
+            )
+            return None
+
+        relative_path = file_path[len(matched_path):].lstrip("/")
+        return f"media-source://media_source/{matched_name}/{relative_path}"
 
     #### ACTIONS ####
 

--- a/custom_components/chime_tts/helpers/services_helper.py
+++ b/custom_components/chime_tts/helpers/services_helper.py
@@ -37,7 +37,15 @@ class ChimeTTSServicesHelper:
                                     say_url_service_func,
                                     supports_response=SupportsResponse.ONLY)
 
-    async def _async_update_chime_lists(self, hass: HomeAssistant, custom_chime_options: str):
+    # Service fields whose chime dropdown options are kept in sync.
+    _CHIME_OPTION_FIELDS = (
+        (SERVICE_SAY, "chime_path"),
+        (SERVICE_SAY, "end_chime_path"),
+        (SERVICE_SAY_URL, "chime_path"),
+        (SERVICE_SAY_URL, "end_chime_path"),
+    )
+
+    async def _async_update_chime_lists(self, hass: HomeAssistant, custom_chime_options: list | None):
         """Modify the chime path drop down options."""
 
         services_yaml = await self._async_parse_services_yaml()
@@ -45,22 +53,67 @@ class ChimeTTSServicesHelper:
             return
 
         try:
-            # Chime Paths
-            final_options: list = DEFAULT_CHIME_OPTIONS + custom_chime_options
-            final_options = sorted(final_options, key=lambda x: x['label'].lower())
-            if not custom_chime_options:
-                final_options.append({"label": "*** Add a local folder path in the configuration for your own custom chimes ***", "value": ""})
-
-            # New chimes detected?
-            if final_options != services_yaml['say']['fields']['chime_path']['selector']['select']['options']:
-                # Update `say` and `say_url` chime path fields
-                services_yaml['say']['fields']['chime_path']['selector']['select']['options'] = list(final_options)
-                services_yaml['say']['fields']['end_chime_path']['selector']['select']['options'] = list(final_options)
-                services_yaml['say_url']['fields']['chime_path']['selector']['select']['options'] = list(final_options)
-                services_yaml['say_url']['fields']['end_chime_path']['selector']['select']['options'] = list(final_options)
+            final_options = self._build_chime_options(custom_chime_options)
         except Exception as e:
-            _LOGGER.error("Unexpected error updating services.yaml: %s", str(e))
-        await self._async_save_services_yaml(services_yaml)
+            _LOGGER.error("Unexpected error building chime options: %s", str(e))
+            return
+
+        # Only write when an option list actually changes, and never after an
+        # error. A previous version saved unconditionally, which re-persisted a
+        # broken services.yaml on every restart (issue #294).
+        changed = False
+        for service_name, field in self._CHIME_OPTION_FIELDS:
+            options = self._get_field_options(services_yaml, service_name, field)
+            if options is None:
+                # Unexpected structure, e.g. a stale file from an older version.
+                # Skip rather than overwrite with a half-built document.
+                _LOGGER.debug("No options list for %s.%s; skipping", service_name, field)
+                continue
+            if options != final_options:
+                self._set_field_options(services_yaml, service_name, field, list(final_options))
+                changed = True
+
+        if changed:
+            await self._async_save_services_yaml(services_yaml)
+
+    @staticmethod
+    def _build_chime_options(custom_chime_options: list | None) -> list:
+        """Return the sorted chime options with every label and value as a str.
+
+        HA's select selector requires string label/value pairs. Custom chime
+        names come from filenames and can look like numbers or booleans; without
+        coercion YAML round-trips them into ints/bools and HA rejects the file
+        (issue #294). Entries missing a label or value are dropped rather than
+        coerced to the string "None".
+        """
+        merged = list(DEFAULT_CHIME_OPTIONS) + list(custom_chime_options or [])
+        options = [
+            {"label": str(o["label"]), "value": str(o["value"])}
+            for o in merged
+            if isinstance(o, dict) and o.get("label") is not None and o.get("value") is not None
+        ]
+        options.sort(key=lambda x: x["label"].lower())
+        if not custom_chime_options:
+            options.append(
+                {
+                    "label": "*** Add a local folder path in the configuration for your own custom chimes ***",
+                    "value": "",
+                }
+            )
+        return options
+
+    @staticmethod
+    def _get_field_options(services_yaml: dict, service_name: str, field: str):
+        """Return the existing options list for a service field, or None if absent."""
+        try:
+            return services_yaml[service_name]["fields"][field]["selector"]["select"]["options"]
+        except (KeyError, TypeError):
+            return None
+
+    @staticmethod
+    def _set_field_options(services_yaml: dict, service_name: str, field: str, options: list) -> None:
+        """Write the options list for a service field."""
+        services_yaml[service_name]["fields"][field]["selector"]["select"]["options"] = options
 
     async def _async_parse_services_yaml(self):
         """Load the services.yaml file into a dictionary."""

--- a/custom_components/chime_tts/helpers/tts_audio_helper.py
+++ b/custom_components/chime_tts/helpers/tts_audio_helper.py
@@ -229,17 +229,6 @@ class TTSAudioHelper:
                 error,
             )
 
-        if media_source_id:
-            try:
-                asyncio.run(tts.async_get_media_source_audio(
-                    hass=self.hass, media_source_id=media_source_id
-                ))
-            except Exception as error:
-                _LOGGER.error(
-                    "   - Error calling tts.async_get_media_source_audio with media_source_id = '%s': %s",
-                    str(media_source_id),
-                    str(error),
-                )
 
 def missing_tts_platform_error(tts_platform):
     """Write a TTS platform specific debug warning when the TTS platform has not been configured."""

--- a/custom_components/chime_tts/helpers/tts_audio_helper.py
+++ b/custom_components/chime_tts/helpers/tts_audio_helper.py
@@ -11,6 +11,8 @@ from .helpers import ChimeTTSHelper
 from ..const import (
     TTS_TIMEOUT_KEY,
     TTS_TIMEOUT_DEFAULT,
+    QUEUE_TIMEOUT_KEY,
+    QUEUE_TIMEOUT_DEFAULT,
     TTS_PLATFORM_KEY,
      FALLBACK_TTS_PLATFORM_KEY,
     AMAZON_POLLY,
@@ -36,12 +38,25 @@ filesystem_helper = FilesystemHelper()
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _clamped_tts_timeout(tts_timeout: int, queue_timeout: int, has_pending_fallback: bool) -> int:
+    """Cap the per-platform TTS timeout so a pending fallback fits in the queue window.
+
+    The queue cancels the whole service call after queue_timeout. When a fallback
+    platform could still run, reserve room for both attempts so the fallback is
+    not cancelled (#232). With no pending fallback, the full timeout is kept.
+    """
+    if not has_pending_fallback:
+        return tts_timeout
+    max_timeout = max(1, (queue_timeout - 2) // 2)
+    return min(tts_timeout, max_timeout)
+
 class TTSAudioHelper:
     """Helper class for generating TTS Audio in Chime TTS."""
 
     _data = {}
 
-    async def async_request_tts_audio(self, hass: HomeAssistant, tts_platform: str, message: str, language: str, cache: bool, options: dict):
+    async def async_request_tts_audio(self, hass: HomeAssistant, tts_platform: str, message: str, language: str, cache: bool, options: dict, is_fallback: bool = False):
         """Send an API request for TTS audio and return the audio file's local filepath."""
         start_time = datetime.now()
 
@@ -52,7 +67,7 @@ class TTSAudioHelper:
 
         # Step 2: Generate TTS audio
         media_source_id, audio_data = await self._generate_tts_audio(
-            hass, tts_platform, message, language, cache, tts_options
+            hass, tts_platform, message, language, cache, tts_options, is_fallback
         )
 
         # Step 3: Process the audio data
@@ -133,13 +148,26 @@ class TTSAudioHelper:
                     )
         return language
 
-    async def _generate_tts_audio(self, hass: HomeAssistant, tts_platform, message, language, cache, tts_options):
+    async def _generate_tts_audio(self, hass: HomeAssistant, tts_platform, message, language, cache, tts_options, is_fallback: bool = False):
         media_source_id = None
         audio_data = None
         if not tts_platform.startswith("tts."):
             tts_platform = f"tts.{tts_platform}"
         try:
             timeout = int(self._data.get(TTS_TIMEOUT_KEY, TTS_TIMEOUT_DEFAULT))
+            queue_timeout = int(self._data.get(QUEUE_TIMEOUT_KEY, QUEUE_TIMEOUT_DEFAULT))
+            # Only reserve room for a fallback when one is configured and this is
+            # not already the fallback attempt.
+            has_pending_fallback = bool(self._data.get(FALLBACK_TTS_PLATFORM_KEY)) and not is_fallback
+            clamped = _clamped_tts_timeout(timeout, queue_timeout, has_pending_fallback)
+            if clamped != timeout:
+                _LOGGER.debug(
+                    "Clamping TTS generation timeout from %ss to %ss so a fallback fits within the %ss queue timeout",
+                    timeout,
+                    clamped,
+                    queue_timeout,
+                )
+                timeout = clamped
             media_source_id = await asyncio.wait_for(
                 asyncio.to_thread(
                     tts.media_source.generate_media_source_id,
@@ -216,6 +244,7 @@ class TTSAudioHelper:
                 language=language,
                 cache=cache,
                 options=options,
+                is_fallback=True,
             )
         _LOGGER.error("...audio_data generation failed")
         return None

--- a/custom_components/chime_tts/helpers/tts_audio_helper.py
+++ b/custom_components/chime_tts/helpers/tts_audio_helper.py
@@ -86,38 +86,45 @@ class TTSAudioHelper:
 
     def _adjust_language_and_voice(self, tts_platform, language, tts_options):
         voice = tts_options.get("voice", None)
-        if (
-            (language or tts_options.get("language"))
-            and tts_platform
-            in [
-                AMAZON_POLLY,
-                GOOGLE_TRANSLATE,
-                NABU_CASA_CLOUD_TTS,
-                IBM_WATSON_TTS,
-                MICROSOFT_EDGE_TTS,
-                MICROSOFT_TTS,
-            ]
-        ):
+        # Nabu Casa cloud can arrive as a full entity id (tts.home_assistant_cloud)
+        # now that platform matching keeps entity ids; map it to the constant so
+        # the language handling below still applies.
+        if tts_platform and tts_platform.lower() in ("tts.home_assistant_cloud", "tts.cloud"):
+            tts_platform = NABU_CASA_CLOUD_TTS
+        language_aware_platforms = [
+            AMAZON_POLLY,
+            GOOGLE_TRANSLATE,
+            GOOGLE_CLOUD,
+            NABU_CASA_CLOUD_TTS,
+            IBM_WATSON_TTS,
+            MICROSOFT_EDGE_TTS,
+            MICROSOFT_TTS,
+        ]
+        if (language or tts_options.get("language")) and tts_platform in language_aware_platforms:
+            if not language:
+                language = tts_options.get("language")
             if tts_platform == IBM_WATSON_TTS and voice is None:
                 tts_options["voice"] = language
                 language = None
-            if tts_platform == MICROSOFT_TTS:
-                if not language:
-                    language = tts_options.get("language")
+            elif tts_platform == MICROSOFT_TTS:
                 tts_options.pop("language", None)
                 if voice:
                     tts_options["type"] = voice
                     tts_options.pop("voice", None)
+            elif tts_platform in (NABU_CASA_CLOUD_TTS, GOOGLE_CLOUD):
+                # These take the language as a separate argument; leaving it in
+                # the options makes the engine reject the call with
+                # "Invalid options found: ['language']" (#242, #210).
+                tts_options.pop("language", None)
         else:
             language = None
 
-        if (
-            tts_platform == NABU_CASA_CLOUD_TTS
-            and voice
-            and not language
-        ):
+        if tts_platform == NABU_CASA_CLOUD_TTS and isinstance(voice, str) and voice and not language:
+            # Styled cloud voices arrive as "name||style"; match on the base name
+            # so the style suffix does not break the language lookup (#307).
+            base_voice = voice.split("||")[0]
             for key, value in nabu_voices.TTS_VOICES.items():
-                if voice in value:
+                if base_voice in value:
                     language = key
                     _LOGGER.debug(
                         " - Setting language to '%s' for Nabu Casa TTS voice: '%s'.",

--- a/custom_components/chime_tts/services.yaml
+++ b/custom_components/chime_tts/services.yaml
@@ -181,6 +181,33 @@ say:
           mode: slider
           step: 1
           unit_of_measurement: semitones
+    repeat:
+      description: Repeat the chime and message this many times
+      example: 2
+      name: Repeat
+      required: false
+      selector:
+        number:
+          max: 10
+          min: 1
+          mode: box
+          step: 1
+    pre_script:
+      description: A script entity to run before the audio plays (e.g. script.front_door)
+      example: script.front_door
+      name: Pre-playback Script
+      required: false
+      selector:
+        entity:
+          domain: script
+    post_script:
+      description: A script entity to run after the audio finishes (e.g. script.front_door)
+      example: script.front_door
+      name: Post-playback Script
+      required: false
+      selector:
+        entity:
+          domain: script
     volume_level:
       description: The volume to use when playing audio
       example: 0.75

--- a/custom_components/chime_tts/translations/en.json
+++ b/custom_components/chime_tts/translations/en.json
@@ -223,7 +223,7 @@
         "step": {
             "init": {
                 "title": "Chime TTS Configuration",
-                "description": "Configurable options for the `chime_tts.say` and `chime_tts.say_url` actions.\r\n\r\nPlease review the [documentation](https://nimroddolev.github.io/chime_tts/docs/documentation/configuration/) for more details",
+                "description": "Configurable options for the `chime_tts.say` and `chime_tts.say_url` actions. See the integration documentation for more details.",
                 "data": {
                     "queue_timeout": "Service call timeout (in seconds)",
                     "tts_timeout": "TTS audio generation timeout (in seconds)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+# Tooling config for tests, coverage, and type checking.
+# Lint config stays in .ruff.toml to match the existing CI workflow.
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = "-q"
+# Make `custom_components.chime_tts` importable when running from the repo root.
+pythonpath = ["."]
+# pytest-homeassistant-custom-component emits known deprecation noise from HA
+# internals; keep test output focused on real failures.
+filterwarnings = [
+    "ignore::DeprecationWarning:homeassistant.*",
+]
+
+[tool.coverage.run]
+source = ["custom_components/chime_tts"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+follow_imports = "silent"
+warn_unused_ignores = false
+warn_redundant_casts = true
+check_untyped_defs = true
+# The integration predates type hints; tighten incrementally rather than
+# failing the whole tree at once.
+disallow_untyped_defs = false
+exclude = ["tests/"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,21 @@
+# Test + lint + type-check stack. Install into a venv:
+#   python3 -m venv .venv && . .venv/bin/activate
+#   pip install -r requirements_test.txt
+#
+# pytest-homeassistant-custom-component pins one HA core version per release.
+# The pin below tracks a recent release; the tox matrix (tox.ini) installs
+# several versions to confirm the integration works across HA releases.
+# Newer HA cores require Python 3.13; on Python 3.12 pip resolves the newest
+# compatible pair (HA 2025.1.x).
+
+pytest-homeassistant-custom-component>=0.13.190
+pydub
+aiofiles
+ruff==0.8.4
+mypy
+
+# HA pulls these in as component-level requirements of the `tts` and ffmpeg
+# components, which chime_tts imports. The base homeassistant wheel does not
+# install them, so list them here for the test environment.
+mutagen
+ha-ffmpeg

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the chime_tts integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures for chime_tts tests."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# pytest-homeassistant-custom-component pins the `custom_components` namespace
+# package to its own testing_config directory, which shadows this repo's
+# integration. Merge our directory into that namespace so
+# `custom_components.chime_tts` imports the code under test.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+import custom_components  # noqa: E402
+
+_OURS = str(_ROOT / "custom_components")
+if _OURS not in custom_components.__path__:
+    custom_components.__path__.append(_OURS)
+
+# pytest-homeassistant-custom-component ships the `hass`, `aioclient_mock`,
+# and `enable_custom_integrations` fixtures, available once it is installed.
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Load chime_tts as a custom integration in every test."""
+    yield
+
+
+@pytest.fixture
+def integration_root():
+    """Return the absolute path to the chime_tts integration package."""
+    from pathlib import Path
+
+    return Path(__file__).resolve().parent.parent / "custom_components" / "chime_tts"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,59 @@
+"""Integration import and setup smoke tests.
+
+The import test alone catches the class of breakage behind several reported
+issues: when a new HA core release removes or moves an API chime_tts imports at
+module load, the integration fails to load entirely (see issues #286, #288).
+Running this across the HA version matrix surfaces that before users hit it.
+"""
+
+import importlib
+
+import pytest
+
+
+def test_integration_package_imports():
+    """The integration and its helpers import under the installed HA core."""
+    pkg = importlib.import_module("custom_components.chime_tts")
+    assert pkg is not None
+
+    for module in (
+        "custom_components.chime_tts.const",
+        "custom_components.chime_tts.helpers.helpers",
+        "custom_components.chime_tts.helpers.media_player_helper",
+        "custom_components.chime_tts.helpers.filesystem",
+        "custom_components.chime_tts.helpers.tts_audio_helper",
+        "custom_components.chime_tts.queue_manager",
+    ):
+        assert importlib.import_module(module) is not None
+
+
+def test_domain_and_service_names():
+    const = importlib.import_module("custom_components.chime_tts.const")
+    assert const.DOMAIN == "chime_tts"
+    assert const.SERVICE_SAY == "say"
+    assert const.SERVICE_SAY_URL == "say_url"
+    assert const.SERVICE_CLEAR_CACHE == "clear_cache"
+
+
+def test_version_matches_manifest():
+    const = importlib.import_module("custom_components.chime_tts.const")
+    # const.VERSION is read from manifest.json at import time.
+    assert const.VERSION, "VERSION should be populated from manifest.json"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_registers_services(hass):
+    """Setting up the integration registers its core services on the bus."""
+    from custom_components.chime_tts import async_setup
+    from custom_components.chime_tts.const import (
+        DOMAIN,
+        SERVICE_SAY,
+        SERVICE_SAY_URL,
+        SERVICE_CLEAR_CACHE,
+    )
+
+    assert await async_setup(hass, {}) is True
+    await hass.async_block_till_done()
+
+    for service in (SERVICE_SAY, SERVICE_SAY_URL, SERVICE_CLEAR_CACHE):
+        assert hass.services.has_service(DOMAIN, service), f"{service} not registered"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,41 @@
+"""Manifest and HACS metadata checks.
+
+These run without the Home Assistant test harness, so they stay green on any
+interpreter and catch the kind of metadata drift hassfest rejects in CI.
+"""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "custom_components" / "chime_tts" / "manifest.json"
+HACS = ROOT / "hacs.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_manifest_is_valid_json():
+    assert MANIFEST.is_file()
+    _load(MANIFEST)
+
+
+def test_manifest_required_keys():
+    manifest = _load(MANIFEST)
+    for key in ("domain", "name", "version", "documentation", "issue_tracker"):
+        assert manifest.get(key), f"manifest missing {key}"
+    assert manifest["domain"] == "chime_tts"
+
+
+def test_manifest_requirements_present():
+    manifest = _load(MANIFEST)
+    reqs = manifest.get("requirements", [])
+    assert "pydub" in reqs
+    assert "aiofiles" in reqs
+
+
+def test_hacs_metadata():
+    hacs = _load(HACS)
+    assert hacs.get("name")
+    assert hacs.get("homeassistant"), "hacs.json must declare a minimum HA version"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -260,3 +260,31 @@ def test_non_string_voice_does_not_crash_cloud_language_lookup():
         helper._adjust_language_and_voice(NABU_CASA_CLOUD_TTS, "", {"voice": 123})
         is None
     )
+
+
+class _ExecHass:
+    """Minimal hass that runs executor jobs inline, for offload tests."""
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+
+async def test_issue_318_async_get_local_path_offloads(monkeypatch):
+    """async_get_local_path runs get_local_path through the executor (#318, #258)."""
+    from custom_components.chime_tts.helpers.filesystem import FilesystemHelper
+
+    helper = FilesystemHelper()
+    hass = _ExecHass()
+    calls = {"n": 0}
+    original = helper.get_local_path
+
+    def _tracked(h, file_path=""):
+        calls["n"] += 1
+        return original(h, file_path)
+
+    monkeypatch.setattr(helper, "get_local_path", _tracked)
+
+    # An absolute path short-circuits inside get_local_path without blocking I/O.
+    result = await helper.async_get_local_path(hass, "/media/chime.mp3")
+    assert result == "/media/chime.mp3"
+    assert calls["n"] == 1, "get_local_path should be invoked via the executor"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -232,12 +232,15 @@ def test_issue_307_styled_cloud_voice_resolves_language():
     from hass_nabucasa import voice as nabu_voices
 
     _lang, voices = next(iter(nabu_voices.TTS_VOICES.items()))
+    # The voice collection is a list on older HA and a dict (name -> label) on
+    # newer HA; take the first voice name either way.
+    first_voice = next(iter(voices))
     helper = TTSAudioHelper()
     styled = helper._adjust_language_and_voice(
-        NABU_CASA_CLOUD_TTS, "", {"voice": f"{voices[0]}||whispering"}
+        NABU_CASA_CLOUD_TTS, "", {"voice": f"{first_voice}||whispering"}
     )
     plain = helper._adjust_language_and_voice(
-        NABU_CASA_CLOUD_TTS, "", {"voice": voices[0]}
+        NABU_CASA_CLOUD_TTS, "", {"voice": first_voice}
     )
     assert styled is not None
     assert styled == plain

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -6,7 +6,36 @@ unfixed code and passes after the fix.
 
 import yaml
 
+from custom_components.chime_tts.helpers.helpers import ChimeTTSHelper
 from custom_components.chime_tts.helpers.services_helper import ChimeTTSServicesHelper
+
+
+class _FakeState:
+    def __init__(self, entity_id):
+        self.entity_id = entity_id
+
+
+class _FakeStates:
+    def __init__(self, entity_ids):
+        self._entity_ids = entity_ids
+
+    def async_all(self, *args):
+        return [_FakeState(i) for i in self._entity_ids]
+
+
+class _FakeServices:
+    def __init__(self, services=()):
+        self._services = set(services)
+
+    def has_service(self, domain, service):
+        return f"{domain}.{service}" in self._services
+
+
+class _FakeHass:
+    def __init__(self, entity_ids=(), services=()):
+        self.states = _FakeStates(list(entity_ids))
+        self.services = _FakeServices(services)
+        self.data = {}
 
 
 def test_issue_294_build_chime_options_coerces_values_to_str():
@@ -57,4 +86,56 @@ def test_issue_294_stale_structure_returns_none_not_crash():
             {"say": {"fields": {"chime_path": {"selector": {}}}}}, "say", "chime_path"
         )
         is None
+    )
+
+
+def test_issue_291_full_entity_id_matches_installed():
+    """A full tts.* entity id selects that entity instead of being rejected (#291)."""
+    helper = ChimeTTSHelper()
+    hass = _FakeHass(entity_ids=["tts.piper", "tts.home_assistant_cloud"])
+    assert helper.get_tts_platform(hass, tts_platform="tts.piper") == "tts.piper"
+    # a bare provider name resolves to the matching entity too
+    assert helper.get_tts_platform(hass, tts_platform="piper") == "tts.piper"
+
+
+def test_issue_308_gemini_not_diverted_to_google_translate():
+    """A Google Generative AI entity is selected, not swapped for Google Translate (#308)."""
+    helper = ChimeTTSHelper()
+    hass = _FakeHass(
+        entity_ids=["tts.google_generative_ai_01jabc", "tts.google_translate_en_com"]
+    )
+    selected = helper.get_tts_platform(
+        hass, tts_platform="tts.google_generative_ai_01jabc"
+    )
+    assert selected == "tts.google_generative_ai_01jabc"
+
+
+def test_issue_241_installed_list_keeps_full_entity_ids():
+    """Installed platforms keep full entity ids rather than first-token truncation (#241)."""
+    helper = ChimeTTSHelper()
+    hass = _FakeHass(entity_ids=["tts.google_generative_ai_x", "tts.microsoft_edge"])
+    installed = helper.get_installed_tts_platforms(hass)
+    assert "tts.google_generative_ai_x" in installed
+    assert "google" not in installed
+
+
+def test_google_translate_fallback_for_unmatched_google_request():
+    """An unmatched Google request still falls back to an installed Google entity."""
+    helper = ChimeTTSHelper()
+    hass = _FakeHass(entity_ids=["tts.google_translate_en_com"])
+    selected = helper.get_tts_platform(hass, tts_platform="tts.google_cloud")
+    assert selected == "tts.google_translate_en_com"
+
+
+def test_ambiguous_google_name_does_not_pick_generative_ai():
+    """A bare 'google' must not silently resolve to a generative-AI entity."""
+    helper = ChimeTTSHelper()
+    hass = _FakeHass(
+        entity_ids=["tts.google_generative_ai_01jabc", "tts.google_translate_en_com"]
+    )
+    # Bare "google" prefixes both providers, so it is ambiguous and falls through
+    # to the Google Translate fallback rather than matching generative AI.
+    assert (
+        helper.get_tts_platform(hass, tts_platform="google")
+        == "tts.google_translate_en_com"
     )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -7,7 +7,18 @@ unfixed code and passes after the fix.
 import yaml
 
 from custom_components.chime_tts.helpers.helpers import ChimeTTSHelper
+from custom_components.chime_tts.helpers.media_player_helper import MediaPlayerHelper
 from custom_components.chime_tts.helpers.services_helper import ChimeTTSServicesHelper
+
+
+class _FakeConfig:
+    def __init__(self, media_dirs):
+        self.media_dirs = media_dirs
+
+
+class _FakeMediaHass:
+    def __init__(self, media_dirs):
+        self.config = _FakeConfig(media_dirs)
 
 
 class _FakeState:
@@ -139,3 +150,49 @@ def test_ambiguous_google_name_does_not_pick_generative_ai():
         helper.get_tts_platform(hass, tts_platform="google")
         == "tts.google_translate_en_com"
     )
+
+
+def test_issue_253_media_content_id_keeps_full_relative_path():
+    """The relative path is preserved exactly, not off-by-one (#253)."""
+    helper = MediaPlayerHelper()
+    hass = _FakeMediaHass({"media": "/media"})
+    cid = helper.get_media_content_id(hass, "/media/sounds/doorbell.mp3")
+    assert cid == "media-source://media_source/media/sounds/doorbell.mp3"
+
+
+def test_issue_289_longest_media_dir_prefix_wins():
+    """The directory with the longest matching path is chosen, regardless of its name (#289)."""
+    helper = MediaPlayerHelper()
+    # "n"'s short path would beat "media"'s longer path under the old
+    # name-length-vs-path-length comparison.
+    hass = _FakeMediaHass({"media": "/media/sub", "n": "/media"})
+    cid = helper.get_media_content_id(hass, "/media/sub/chime.mp3")
+    assert cid == "media-source://media_source/media/chime.mp3"
+
+
+def test_issue_289_outside_media_dir_returns_none_not_garbage():
+    """A file outside any media dir returns None instead of a corrupt id (#289)."""
+    helper = MediaPlayerHelper()
+    hass = _FakeMediaHass({"media": "/media"})
+    assert helper.get_media_content_id(hass, "/config/www/chime.mp3") is None
+
+
+def test_issue_289_sibling_prefix_directory_not_matched():
+    """A dir /media must not claim a sibling path like /media-other (#289)."""
+    helper = MediaPlayerHelper()
+    hass = _FakeMediaHass({"media": "/media"})
+    assert helper.get_media_content_id(hass, "/media-other/chime.mp3") is None
+
+
+def test_media_content_id_trailing_slash_media_dir():
+    """A configured media dir with a trailing slash still resolves correctly."""
+    helper = MediaPlayerHelper()
+    hass = _FakeMediaHass({"media": "/media/"})
+    cid = helper.get_media_content_id(hass, "/media/chime.mp3")
+    assert cid == "media-source://media_source/media/chime.mp3"
+
+
+def test_media_content_id_missing_path_returns_none():
+    helper = MediaPlayerHelper()
+    hass = _FakeMediaHass({"media": "/media"})
+    assert helper.get_media_content_id(hass, "") is None

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -288,3 +288,37 @@ async def test_issue_318_async_get_local_path_offloads(monkeypatch):
     result = await helper.async_get_local_path(hass, "/media/chime.mp3")
     assert result == "/media/chime.mp3"
     assert calls["n"] == 1, "get_local_path should be invoked via the executor"
+
+
+def test_issue_282_cache_hit_does_not_reapply_baked_in_filter():
+    """A cached file's conversion is not re-applied on a cache hit (#282, #280)."""
+    from custom_components.chime_tts import _should_reapply_conversion_on_cache_hit
+    from custom_components.chime_tts.const import FFMPEG_ARGS_ALEXA
+
+    # A volume-boost filter is already baked into the cached file; never re-apply.
+    assert _should_reapply_conversion_on_cache_hit("-af volume=1.5", True) is False
+    assert _should_reapply_conversion_on_cache_hit("-af volume=1.5", False) is False
+    # Alexa is the only case that back-fills, and only when not yet compatible.
+    assert _should_reapply_conversion_on_cache_hit(FFMPEG_ARGS_ALEXA, False) is True
+    assert _should_reapply_conversion_on_cache_hit(FFMPEG_ARGS_ALEXA, True) is False
+
+
+def test_issue_282_conversion_is_part_of_cache_key():
+    """Different audio conversions produce different cache keys (#282, #280).
+
+    The conversion is parsed into the params under "ffmpeg_args", so a cache
+    entry must be unique per conversion; otherwise skipping re-application on a
+    cache hit would serve the wrong conversion.
+    """
+    from custom_components.chime_tts import get_filename_hash_from_service_data
+
+    base = {"message": "hi"}
+    boost = get_filename_hash_from_service_data(
+        {**base, "ffmpeg_args": "-af volume=1.5"}, {}
+    )
+    quiet = get_filename_hash_from_service_data(
+        {**base, "ffmpeg_args": "-af volume=0.5"}, {}
+    )
+    plain = get_filename_hash_from_service_data(base, {})
+    assert boost != quiet
+    assert boost != plain

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -325,3 +325,20 @@ def test_issue_282_conversion_is_part_of_cache_key():
     plain = get_filename_hash_from_service_data(base, {})
     assert boost != quiet
     assert boost != plain
+
+
+def test_issue_232_tts_timeout_clamped_to_leave_room_for_fallback():
+    """The per-platform TTS timeout leaves room for a fallback within the queue timeout (#232)."""
+    from custom_components.chime_tts.helpers.tts_audio_helper import (
+        _clamped_tts_timeout,
+    )
+
+    # With a pending fallback, a 30s primary under a 60s queue is capped so both fit.
+    assert _clamped_tts_timeout(30, 60, True) == 29
+    # A timeout already under the cap is unchanged.
+    assert _clamped_tts_timeout(10, 60, True) == 10
+    # Never drops below 1 second.
+    assert _clamped_tts_timeout(30, 1, True) == 1
+    # With no pending fallback, the full timeout is kept (not halved).
+    assert _clamped_tts_timeout(30, 60, False) == 30
+    assert _clamped_tts_timeout(55, 60, False) == 55

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -6,9 +6,11 @@ unfixed code and passes after the fix.
 
 import yaml
 
+from custom_components.chime_tts.const import GOOGLE_CLOUD, NABU_CASA_CLOUD_TTS
 from custom_components.chime_tts.helpers.helpers import ChimeTTSHelper
 from custom_components.chime_tts.helpers.media_player_helper import MediaPlayerHelper
 from custom_components.chime_tts.helpers.services_helper import ChimeTTSServicesHelper
+from custom_components.chime_tts.helpers.tts_audio_helper import TTSAudioHelper
 
 
 class _FakeConfig:
@@ -208,3 +210,53 @@ def test_media_content_id_missing_path_returns_none():
     helper = MediaPlayerHelper()
     hass = _FakeMediaHass({"media": "/media"})
     assert helper.get_media_content_id(hass, "") is None
+
+
+def test_issue_210_google_cloud_language_preserved():
+    """Google Cloud keeps the requested language instead of discarding it (#210)."""
+    helper = TTSAudioHelper()
+    assert helper._adjust_language_and_voice(GOOGLE_CLOUD, "nl-BE", {}) == "nl-BE"
+
+
+def test_issue_242_cloud_language_moved_out_of_options():
+    """Cloud TTS gets language as an argument, not in options (#242)."""
+    helper = TTSAudioHelper()
+    options = {"language": "de"}
+    result = helper._adjust_language_and_voice(NABU_CASA_CLOUD_TTS, "", options)
+    assert result == "de"
+    assert "language" not in options
+
+
+def test_issue_307_styled_cloud_voice_resolves_language():
+    """A styled cloud voice (name||style) resolves the same language as the plain voice (#307)."""
+    from hass_nabucasa import voice as nabu_voices
+
+    _lang, voices = next(iter(nabu_voices.TTS_VOICES.items()))
+    helper = TTSAudioHelper()
+    styled = helper._adjust_language_and_voice(
+        NABU_CASA_CLOUD_TTS, "", {"voice": f"{voices[0]}||whispering"}
+    )
+    plain = helper._adjust_language_and_voice(
+        NABU_CASA_CLOUD_TTS, "", {"voice": voices[0]}
+    )
+    assert styled is not None
+    assert styled == plain
+
+
+def test_cloud_entity_id_form_language_handled():
+    """Nabu cloud as a full entity id still gets language moved out of options."""
+    helper = TTSAudioHelper()
+    options = {"language": "fr"}
+    result = helper._adjust_language_and_voice("tts.home_assistant_cloud", "", options)
+    assert result == "fr"
+    assert "language" not in options
+
+
+def test_non_string_voice_does_not_crash_cloud_language_lookup():
+    """A non-string voice must not raise in the cloud language lookup."""
+    helper = TTSAudioHelper()
+    # Should simply skip the lookup and return None, not raise AttributeError.
+    assert (
+        helper._adjust_language_and_voice(NABU_CASA_CLOUD_TTS, "", {"voice": 123})
+        is None
+    )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -342,3 +342,40 @@ def test_issue_232_tts_timeout_clamped_to_leave_room_for_fallback():
     # With no pending fallback, the full timeout is kept (not halved).
     assert _clamped_tts_timeout(30, 60, False) == 30
     assert _clamped_tts_timeout(55, 60, False) == 55
+
+
+def test_issue_314_repeat_is_part_of_cache_key():
+    """Different repeat counts produce different cache keys (#314)."""
+    from custom_components.chime_tts import get_filename_hash_from_service_data
+
+    base = {"message": "hi"}
+    assert get_filename_hash_from_service_data(
+        base, {}
+    ) != get_filename_hash_from_service_data({**base, "repeat": 3}, {})
+    assert get_filename_hash_from_service_data(
+        {**base, "repeat": 2}, {}
+    ) != get_filename_hash_from_service_data({**base, "repeat": 3}, {})
+
+
+async def test_issue_310_runs_configured_script_before_after_tts():
+    """A configured pre/post script is invoked as a script service (#310)."""
+    from custom_components.chime_tts import async_run_script
+
+    calls = []
+
+    class _Services:
+        async def async_call(self, domain, service, **kwargs):
+            calls.append((domain, service))
+
+    class _Hass:
+        services = _Services()
+
+    hass = _Hass()
+    await async_run_script(hass, "script.front_door")
+    assert ("script", "front_door") in calls
+
+    # A non-script entity is ignored, and None is a no-op.
+    calls.clear()
+    await async_run_script(hass, "light.kitchen")
+    await async_run_script(hass, None)
+    assert calls == []

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,60 @@
+"""Regression tests, one per fixed GitHub issue.
+
+Each fix lands with a test named `test_issue_<number>` that fails against the
+unfixed code and passes after the fix.
+"""
+
+import yaml
+
+from custom_components.chime_tts.helpers.services_helper import ChimeTTSServicesHelper
+
+
+def test_issue_294_build_chime_options_coerces_values_to_str():
+    """Numeric/boolean-looking chime names stay strings so services.yaml parses (#294)."""
+    custom = [
+        {"label": "060", "value": "/config/chimes/060.mp3"},
+        {"label": 12, "value": 12},  # adversarial non-str entry
+        {"label": "yes", "value": "yes"},
+        {"value": "/missing/label.mp3"},  # malformed: no label, dropped
+        {"label": "no-value", "value": None},  # None value, dropped (not "None")
+        "not-a-dict",  # malformed, dropped
+    ]
+    options = ChimeTTSServicesHelper._build_chime_options(custom)
+
+    assert options
+    for option in options:
+        assert isinstance(option["label"], str)
+        assert isinstance(option["value"], str)
+
+    values = [o["value"] for o in options]
+    labels = [o["label"] for o in options]
+    assert "12" in values, "int value should be coerced to str"
+    assert "/missing/label.mp3" not in values, "entry without a label should be dropped"
+    assert "no-value" not in labels, "entry with a None value should be dropped"
+    assert "None" not in values, "None must not be coerced to the string 'None'"
+
+
+def test_issue_294_round_trips_through_yaml_as_str():
+    """Options survive a YAML dump/load with their values intact as str (#294)."""
+    options = ChimeTTSServicesHelper._build_chime_options(
+        [
+            {"label": "060", "value": "/m/060.mp3"},
+            {"label": "on", "value": "on"},
+            {"label": "3.5", "value": "3.5"},
+        ]
+    )
+    reloaded = yaml.safe_load(yaml.safe_dump({"options": options}))["options"]
+    for option in reloaded:
+        assert isinstance(option["label"], str)
+        assert isinstance(option["value"], str)
+
+
+def test_issue_294_stale_structure_returns_none_not_crash():
+    """A services.yaml missing the expected nesting yields None rather than raising (#294)."""
+    assert ChimeTTSServicesHelper._get_field_options({}, "say", "chime_path") is None
+    assert (
+        ChimeTTSServicesHelper._get_field_options(
+            {"say": {"fields": {"chime_path": {"selector": {}}}}}, "say", "chime_path"
+        )
+        is None
+    )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -192,6 +192,18 @@ def test_media_content_id_trailing_slash_media_dir():
     assert cid == "media-source://media_source/media/chime.mp3"
 
 
+def test_issue_275_sonos_explicit_volume_set_call():
+    """Sonos gets an explicit volume_set at the target level before the announce (#275, #256)."""
+    from custom_components.chime_tts import _sonos_volume_set_call
+
+    call = _sonos_volume_set_call("media_player.kitchen", 50)
+    assert call["service"] == "volume_set"
+    assert call["service_data"]["volume_level"] == 0.5
+    # out-of-range percentages are clamped to a valid 0.0-1.0 level
+    assert _sonos_volume_set_call("x", 150)["service_data"]["volume_level"] == 1.0
+    assert _sonos_volume_set_call("x", -5)["service_data"]["volume_level"] == 0.0
+
+
 def test_media_content_id_missing_path_returns_none():
     helper = MediaPlayerHelper()
     hass = _FakeMediaHass({"media": "/media"})

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,40 @@
+# Multi-version test matrix.
+#
+# pytest-homeassistant-custom-component bundles one HA core version per release,
+# so each env pins a plugin version to pin an HA version. Newer HA cores require
+# Python 3.13; on Python 3.12 the newest installable pair is HA 2025.1.x.
+#
+# Locally only the interpreters you have installed will run. CI runs the full
+# matrix (see .github/workflows/tests.yml) and is the source of truth.
+#
+# To extend the matrix, add an env with the plugin version that ships the HA
+# release you want to cover. Plugin patch numbers track HA releases; check
+# https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/releases
+
+[tox]
+envlist = py312-ha20251, py313-hamid, py313-halatest
+skip_missing_interpreters = true
+
+[testenv]
+deps =
+    pydub
+    aiofiles
+    mutagen
+    ha-ffmpeg
+    py312-ha20251: pytest-homeassistant-custom-component==0.13.190
+    py313-hamid: pytest-homeassistant-custom-component==0.13.200
+    py313-halatest: pytest-homeassistant-custom-component
+commands =
+    pytest tests/ --cov=custom_components/chime_tts --cov-report=term-missing {posargs}
+
+[testenv:lint]
+deps = ruff==0.8.4
+commands =
+    ruff check custom_components/chime_tts tests
+    ruff format --check custom_components/chime_tts tests
+
+[testenv:type]
+deps =
+    mypy
+    pytest-homeassistant-custom-component
+commands = mypy custom_components/chime_tts


### PR DESCRIPTION
Chime TTS is broken on recent Home Assistant releases (see #318, #289, #291, and home-assistant/core#88714). This restores it to working order on current HA, adds a test suite run against multiple HA versions, and includes two small features. Validated against HA 2026.6.3 and 2025.1.4.

## Fixes
- **No audio / silent playback (#289, #253):** rewrite `get_media_content_id` with a correct longest-path, boundary-aware media-dir match, exact prefix strip, and resolution against `hass.config.media_dirs` (also fixes `say_url`).
- **Chime plays but no TTS (#291, #308, #241):** stop truncating `tts.*` entity ids to their first token; match bare provider names and full entity ids; Google Gemini is no longer diverted to Google Translate.
- **Blocking calls on the event loop (#318, #258):** offload local path resolution to an executor.
- **services.yaml parse failure (#294):** coerce chime options to strings, navigate the YAML safely, and only rewrite on a real change.
- **Cache + filter double-applies (#282, #280):** include the conversion in the cache key and stop re-applying it on cache hits (only Alexa entries are back-filled).
- **TTS language/voice (#242, #307, #210):** cloud / Google Cloud language handling and styled-voice (`name||style`) lookup.
- **Sonos announcement volume (#275, #256):** explicit `volume_set` before the announce when snapshot/restore is enabled.
- **Fallback not invoked on timeout (#232), error-path `asyncio.run` crash (#272), default temp-folder config error (#306), f-string SyntaxWarnings (#288).**

## Features
- `repeat`: play the chime and message multiple times (#314).
- `pre_script` / `post_script`: run a script entity before and after playback (#310).

## Tests
Adds a pytest suite (`pytest-homeassistant-custom-component`) with regression tests per fixed issue, plus a CI matrix across HA versions. All green on HA 2026.6.3 and 2025.1.4.

## Breaking changes
- The TTS platform now stores/returns the full `tts.*` entity id rather than a truncated provider name. Existing configurations keep working (matching accepts both forms), but the platform dropdown lists full entity ids, and a request that previously fell through to Google Translate may now resolve to the actual provider (e.g. Google Generative AI).
- Sonos: with snapshot/restore enabled, the announcement volume is now applied via an explicit `volume_set` and restored afterward.

## Related
Complements #315 (Google Cast volume spikes, by @lolcatnip) and #309 (Squeezebox announcement volume, by @whc2001), which can be merged independently. Supersedes the narrower #311.

Some items remain for follow-up and are intentionally not included here: migrating off the deprecated `async_get_media_source_audio` (it still works on 2026.6.3; the `async_create_stream` replacement needs a larger rework), and several device-specific playback-resume issues that need hardware to verify.