### PR TITLE
fix: preserve Hebrew niqqud for TTS platforms that support it

### DIFF
--- a/custom_components/chime_tts/const.py
+++ b/custom_components/chime_tts/const.py
@@ -133,4 +133,7 @@ PIPER = "tts.piper"
 VOICE_RSS = "voicerss"
 YANDEX_TTS = "yandextts"
 
+# Platforms verified to pronounce Hebrew niqqud. Any other platform has it stripped.
+NIQQUD_SUPPORTED_TTS_PLATFORMS = [GOOGLE_TRANSLATE]
+
 QUOTE_CHAR_SUBSTITUTE = "🁢"

--- a/custom_components/chime_tts/helpers/helpers.py
+++ b/custom_components/chime_tts/helpers/helpers.py
@@ -36,6 +36,7 @@ from ..const import (
     PIPER,
     VOICE_RSS,
     YANDEX_TTS,
+    NIQQUD_SUPPORTED_TTS_PLATFORMS,
     QUOTE_CHAR_SUBSTITUTE
 )
 from homeassistant.core import HomeAssistant
@@ -46,6 +47,17 @@ from pydub import AudioSegment
 filesystem_helper = FilesystemHelper()
 
 _LOGGER = logging.getLogger(__name__)
+
+TTS_ENTITY_PREFIX = "tts."
+
+# Excludes U+05BE/U+05C0/U+05C3/U+05C6: punctuation, not diacritics. The maqaf
+# separates words, so removing it would join them.
+NIQQUD_PATTERN = re.compile(r"[\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7]")
+
+# Per-language/TLD entities, eg "google_en_com". Narrow, so google_cloud and
+# google_generative_ai do not match.
+GOOGLE_TRANSLATE_ENTITY_PATTERN = re.compile(r"^google_[a-z]{2,3}_[a-z]{2,3}$")
+
 class ChimeTTSHelper:
     """Helper functions for Chime TTS."""
 
@@ -204,14 +216,31 @@ class ChimeTTSHelper:
 
     def remove_niqqud(self, message_text: str):
         """Replace Hebrew niqqud characters with non-voweled characters."""
-        # Unicode range for Hebrew niqqud is \u0591 to \u05C7
-        niqqud_pattern = re.compile(r'[\u0591-\u05C7]')
-        cleaned_text = niqqud_pattern.sub('', message_text)
-        return cleaned_text
+        return NIQQUD_PATTERN.sub("", message_text)
+
+    def normalize_tts_platform_name(self, tts_platform: str):
+        """Reduce a TTS platform name or TTS entity_id to its bare platform name."""
+        if not tts_platform:
+            return ""
+        normalized = self.get_stripped_tts_platform(str(tts_platform)).lower()
+        if normalized.startswith(TTS_ENTITY_PREFIX):
+            normalized = normalized[len(TTS_ENTITY_PREFIX):]
+        if (normalized.startswith(GOOGLE_TRANSLATE)
+                or GOOGLE_TRANSLATE_ENTITY_PATTERN.match(normalized)):
+            normalized = GOOGLE_TRANSLATE
+        return normalized
+
+    def supports_niqqud(self, tts_platform: str):
+        """Return whether the TTS platform pronounces Hebrew niqqud. Unknown platforms do not."""
+        supported = {
+            self.normalize_tts_platform_name(platform)
+            for platform in NIQQUD_SUPPORTED_TTS_PLATFORMS
+        }
+        return self.normalize_tts_platform_name(tts_platform) in supported
 
     def parse_message(self, message_string: str):
         """Parse the message string/YAML object into segments dictionary."""
-        message_string = self.remove_niqqud(message_string)
+        message_string = str(message_string)
         segments = []
         if len(message_string) == 0 or message_string == "None":
             return []

--- a/custom_components/chime_tts/helpers/tts_audio_helper.py
+++ b/custom_components/chime_tts/helpers/tts_audio_helper.py
@@ -50,18 +50,35 @@ class TTSAudioHelper:
         if not tts_platform:
             return None
 
-        # Step 2: Generate TTS audio
+        # Step 2: Adapt the message to the resolved platform
+        platform_message = self._adapt_message_to_platform(message, tts_platform)
+
+        # Step 3: Generate TTS audio
         media_source_id, audio_data = await self._generate_tts_audio(
-            hass, tts_platform, message, language, cache, tts_options
+            hass, tts_platform, platform_message, language, cache, tts_options
         )
 
-        # Step 3: Process the audio data
+        # Step 4: Process the audio data
         audio = await self._process_audio_data(hass, media_source_id, audio_data, start_time)
         if audio:
             return audio
 
-        # Step 4: Retry with fallback platform if needed
+        # Step 5: Retry with fallback platform if needed. The original message is
+        # passed on, so it is re-adapted for the fallback platform.
         return await self._retry_with_fallback(hass, tts_platform, message, language, cache, options)
+
+    def _adapt_message_to_platform(self, message: str, tts_platform: str):
+        """Remove any text the resolved TTS platform cannot pronounce."""
+        if helpers.supports_niqqud(tts_platform):
+            return message
+
+        cleaned_message = helpers.remove_niqqud(message)
+        if cleaned_message != message:
+            _LOGGER.debug(
+                " - Removed Hebrew niqqud: '%s' is not known to support it",
+                tts_platform,
+            )
+        return cleaned_message
 
     def _prepare_tts_request(self, hass: HomeAssistant, tts_platform, message, language, options):
         if not options:


### PR DESCRIPTION
## Summary

Hebrew text with niqqud (vowel points) is spoken as if it were unvowelled. Sending the same text straight to Google Translate TTS pronounces it correctly, so the difference comes from Chime TTS, not the engine.

`parse_message()` calls `remove_niqqud()` on every message, stripping the whole `U+0591–U+05C7` range before the text reaches any TTS platform (`helpers.py`, introduced in c5a5ae0).

Because niqqud selects which word is spoken, this is not cosmetic — `סַפָּר` (*sapar*, barber) and `סֵפֶר` (*sefer*, book) share the same consonants and both collapse to `ספר`.

## Steps to reproduce

```yaml
service: chime_tts.say
data:
  tts_platform: google_translate
  language: iw
  message: "סַפָּר"
  entity_id: media_player.kitchen
```

**Expected:** *sapar*, matching what Google Translate says for the same string.
**Actual:** *sefer* — the niqqud is discarded before the request is made.

## Verification

Tested against the live Google Translate endpoint.

Minimal pairs — identical consonants, niqqud alone changes the word:

| text | audio |
|---|---|
| `ילד` bare / `יֶלֶד` *yeled* / `יָלַד` *yalad* | 7488 / 7488 / **7872** |
| `ספר` bare / `סֵפֶר` *sefer* / `סַפָּר` *sapar* | 8064 / 8064 / **8256** |

End-to-end through the pipeline with `סַפָּר`:

```
direct Google TTS          : 8256 bytes  <-- target
before (sent 'ספר')        : 8064 bytes  DIFFERS -> wrong word spoken
after  (sent 'סַפָּר')       : 8256 bytes  MATCHES target
```

Also confirmed that `tts.piper`, `tts.google_cloud` and `tts.google_generative_ai` still receive stripped text, and that `google_translate`, `tts.google_translate`, `Google Translate` and `tts.google_en_com` all resolve as supporting.

### Tested end-to-end on a real Home Assistant

Beyond the unit-level checks above, I deployed this to my own Home Assistant (HA OS) running `v1.3.0-beta1` and exercised it through `chime_tts.say` on real media players. Vowelled Hebrew now comes out correctly via Google Translate, and the rest of the integration behaves as before.

Since my install tracks the 1.3 beta rather than `main`, what I deployed was this change ported onto `dev/v1.3.x` — same logic, adapted to that branch's restructured `async_request_tts_audio()`. So the behaviour is confirmed on a live HA, on the branch that is currently shipping to users.
