### PR TITLE
fix: preserve Hebrew niqqud for TTS platforms that support it

### DIFF
--- a/custom_components/chime_tts/const.py
+++ b/custom_components/chime_tts/const.py
@@ -167,4 +167,7 @@ PIPER = "tts.piper"
 VOICE_RSS = "voicerss"
 YANDEX_TTS = "yandextts"
 
+# Platforms verified to pronounce Hebrew niqqud. Any other platform has it stripped.
+NIQQUD_SUPPORTED_TTS_PLATFORMS = [GOOGLE_TRANSLATE]
+
 QUOTE_CHAR_SUBSTITUTE = "🁢"

--- a/custom_components/chime_tts/helpers/helpers.py
+++ b/custom_components/chime_tts/helpers/helpers.py
@@ -36,6 +36,7 @@ from ..const import (
     PIPER,
     VOICE_RSS,
     YANDEX_TTS,
+    NIQQUD_SUPPORTED_TTS_PLATFORMS,
     QUOTE_CHAR_SUBSTITUTE
 )
 from homeassistant.core import HomeAssistant
@@ -47,6 +48,17 @@ from pydub import AudioSegment
 filesystem_helper = FilesystemHelper()
 
 _LOGGER = logging.getLogger(__name__)
+
+TTS_ENTITY_PREFIX = "tts."
+
+# Excludes U+05BE/U+05C0/U+05C3/U+05C6: punctuation, not diacritics. The maqaf
+# separates words, so removing it would join them.
+NIQQUD_PATTERN = re.compile(r"[\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7]")
+
+# Per-language/TLD entities, eg "google_en_com". Narrow, so google_cloud and
+# google_generative_ai do not match.
+GOOGLE_TRANSLATE_ENTITY_PATTERN = re.compile(r"^google_[a-z]{2,3}_[a-z]{2,3}$")
+
 _KNOWN_TTS_PROVIDER_ALIASES = {
     "amazon_polly": AMAZON_POLLY,
     "amazonpolly": AMAZON_POLLY,
@@ -276,14 +288,31 @@ class ChimeTTSHelper:
 
     def remove_niqqud(self, message_text: str):
         """Replace Hebrew niqqud characters with non-voweled characters."""
-        # Unicode range for Hebrew niqqud is \u0591 to \u05C7
-        niqqud_pattern = re.compile(r'[\u0591-\u05C7]')
-        cleaned_text = niqqud_pattern.sub('', message_text)
-        return cleaned_text
+        return NIQQUD_PATTERN.sub("", message_text)
+
+    def normalize_tts_platform_name(self, tts_platform: str):
+        """Reduce a TTS platform name or TTS entity_id to its bare platform name."""
+        if not tts_platform:
+            return ""
+        normalized = self.get_stripped_tts_platform(str(tts_platform)).lower()
+        if normalized.startswith(TTS_ENTITY_PREFIX):
+            normalized = normalized[len(TTS_ENTITY_PREFIX):]
+        if (normalized.startswith(GOOGLE_TRANSLATE)
+                or GOOGLE_TRANSLATE_ENTITY_PATTERN.match(normalized)):
+            normalized = GOOGLE_TRANSLATE
+        return normalized
+
+    def supports_niqqud(self, tts_platform: str):
+        """Return whether the TTS platform pronounces Hebrew niqqud. Unknown platforms do not."""
+        supported = {
+            self.normalize_tts_platform_name(platform)
+            for platform in NIQQUD_SUPPORTED_TTS_PLATFORMS
+        }
+        return self.normalize_tts_platform_name(tts_platform) in supported
 
     def parse_message(self, message_string: str):
         """Parse the message string/YAML object into segments dictionary."""
-        message_string = self.remove_niqqud(message_string)
+        message_string = str(message_string)
         segments = []
         if len(message_string) == 0 or message_string == "None":
             return []

--- a/custom_components/chime_tts/helpers/tts_audio_helper.py
+++ b/custom_components/chime_tts/helpers/tts_audio_helper.py
@@ -74,6 +74,9 @@ class TTSAudioHelper:
         if not tts_platform:
             return None
 
+        # Adapt the message to the resolved platform
+        platform_message = self._adapt_message_to_platform(message, tts_platform)
+
         # Steps 2-3: Generate and retrieve TTS audio under one deadline. A
         # media-source ID can be produced before the provider makes its network
         # request, so timing only generation can prevent a fallback attempt.
@@ -81,7 +84,7 @@ class TTSAudioHelper:
         try:
             audio = await asyncio.wait_for(
                 self._async_generate_and_process_audio(
-                    hass, tts_platform, message, language, cache, tts_options,
+                    hass, tts_platform, platform_message, language, cache, tts_options,
                     is_fallback, start_time, timeout,
                 ),
                 timeout=timeout,
@@ -93,8 +96,22 @@ class TTSAudioHelper:
         if audio:
             return audio
 
-        # Step 4: Retry with fallback platform if needed
+        # Step 4: Retry with fallback platform if needed. The original message is
+        # passed on, so it is re-adapted for the fallback platform.
         return await self._retry_with_fallback(hass, tts_platform, message, language, cache, options)
+
+    def _adapt_message_to_platform(self, message: str, tts_platform: str):
+        """Remove any text the resolved TTS platform cannot pronounce."""
+        if helpers.supports_niqqud(tts_platform):
+            return message
+
+        cleaned_message = helpers.remove_niqqud(message)
+        if cleaned_message != message:
+            _LOGGER.debug(
+                " - Removed Hebrew niqqud: '%s' is not known to support it",
+                tts_platform,
+            )
+        return cleaned_message
 
     @property
     def last_error_message(self) -> str | None:

--- a/tests/test_mp3_settings.py
+++ b/tests/test_mp3_settings.py
@@ -299,11 +299,42 @@ def test_parse_message_falls_back_to_tts_for_invalid_yaml_segments(helper: Chime
     assert segments == [{"type": "tts", "message": message}]
 
 
-def test_parse_message_removes_niqqud(helper: ChimeTTSHelper) -> None:
-    """Hebrew niqqud should be stripped before creating the TTS segment."""
+def test_parse_message_preserves_niqqud(helper: ChimeTTSHelper) -> None:
+    """Niqqud survives parsing; stripping it is the TTS platform's decision."""
     segments = helper.parse_message("שָׁלוֹם")
 
-    assert segments == [{"type": "tts", "message": "שלום"}]
+    assert segments == [{"type": "tts", "message": "שָׁלוֹם"}]
+
+
+def test_remove_niqqud_strips_vowels_and_cantillation(helper: ChimeTTSHelper) -> None:
+    """Vowel points and cantillation marks are diacritics and are removed."""
+    assert helper.remove_niqqud("שָׁלוֹם") == "שלום"
+    assert helper.remove_niqqud("בְּרֵאשִׁ֖ית") == "בראשית"
+
+
+def test_remove_niqqud_preserves_hebrew_punctuation(helper: ChimeTTSHelper) -> None:
+    """The maqaf separates words, so removing it would join them."""
+    assert helper.remove_niqqud("כָּל־הָעוֹלָם") == "כל־העולם"
+    assert helper.remove_niqqud("אָ׀ב") == "א׀ב"
+    assert helper.remove_niqqud("סוֹף׃") == "סוף׃"
+
+
+@pytest.mark.parametrize(
+    "tts_platform",
+    ["google_translate", "tts.google_translate", "Google Translate", "tts.google_en_com"],
+)
+def test_supports_niqqud_for_google_translate(helper: ChimeTTSHelper, tts_platform: str) -> None:
+    """Google Translate pronounces niqqud, including its per-language entities."""
+    assert helper.supports_niqqud(tts_platform) is True
+
+
+@pytest.mark.parametrize(
+    "tts_platform",
+    ["tts.piper", "tts.google_cloud", "tts.google_generative_ai", "cloud", "edge_tts", "", None],
+)
+def test_does_not_support_niqqud(helper: ChimeTTSHelper, tts_platform) -> None:
+    """Unknown platforms, and sibling Google products, keep the stripping behaviour."""
+    assert helper.supports_niqqud(tts_platform) is False
 
 
 def test_add_atempo_values_supports_sub_half_values(helper: ChimeTTSHelper) -> None:

--- a/tests/test_tts_audio_helper_additional.py
+++ b/tests/test_tts_audio_helper_additional.py
@@ -132,3 +132,22 @@ async def test_request_timeout_and_generation_errors(
         hass, "primary", "hello", None, False, {}
     ) == (None, None)
     assert "failed to generate" in helper.last_error_message
+
+
+@pytest.mark.parametrize(
+    ("tts_platform", "expected"),
+    [
+        ("google_translate", "סַפָּר"),
+        ("tts.google_en_com", "סַפָּר"),
+        ("tts.piper", "ספר"),
+        ("tts.google_generative_ai", "ספר"),
+    ],
+)
+def test_adapt_message_to_platform(tts_platform: str, expected: str) -> None:
+    """Niqqud reaches platforms that pronounce it, and is stripped for the rest."""
+    assert TTSAudioHelper()._adapt_message_to_platform("סַפָּר", tts_platform) == expected
+
+
+def test_adapt_message_to_platform_keeps_maqaf_when_stripping() -> None:
+    """Stripping niqqud must not remove the maqaf and join the two words."""
+    assert TTSAudioHelper()._adapt_message_to_platform("כָּל־הָעוֹלָם", "tts.piper") == "כל־העולם"


### PR DESCRIPTION
Retargets #327 to `dev/v1.3.x` as requested.

## Summary

Hebrew text with niqqud (vowel points) is spoken as if it were unvowelled. Sending the same text straight to Google Translate TTS pronounces it correctly, so the difference comes from Chime TTS, not the engine.

`parse_message()` calls `remove_niqqud()` on every message, stripping the whole `U+0591–U+05C7` range before the text reaches any TTS platform (`helpers.py`, introduced in c5a5ae0).

Because niqqud selects which word is spoken, this is not cosmetic — `סַפָּר` (*sapar*, barber) and `סֵפֶר` (*sefer*, book) share the same consonants and both collapse to `ספר`.

## Steps to reproduce

```yaml
service: chime_tts.say
data:
  tts_platform: google_translate
  language: iw
  message: "סַפָּר"
  entity_id: media_player.kitchen
```

**Expected:** *sapar*, matching what Google Translate says for the same string.
**Actual:** *sefer* — the niqqud is discarded before the request is made.

## Tests

`test_parse_message_removes_niqqud` asserted the old behaviour and is replaced by `test_parse_message_preserves_niqqud`. Added regression tests for diacritic removal, Hebrew punctuation preservation, platform detection and per-platform message adaptation.

`230 passed, 1 failed, 26 skipped` — the failure is `test_mp3_artifacts_have_expected_audio_fingerprint[pitch12]`, which fails identically on an unmodified `dev/v1.3.x` here (the recorded PCM md5 depends on the local ffmpeg build).

## Verification

Tested against the live Google Translate endpoint.

Minimal pairs — identical consonants, niqqud alone changes the word:

| text | audio |
|---|---|
| `ילד` bare / `יֶלֶד` *yeled* / `יָלַד` *yalad* | 7488 / 7488 / **7872** |
| `ספר` bare / `סֵפֶר` *sefer* / `סַפָּר` *sapar* | 8064 / 8064 / **8256** |

End-to-end through the pipeline with `סַפָּר`:

```
direct Google TTS          : 8256 bytes  <-- target
before (sent 'ספר')        : 8064 bytes  DIFFERS -> wrong word spoken
after  (sent 'סַפָּר')       : 8256 bytes  MATCHES target
```

Also confirmed that `tts.piper`, `tts.google_cloud` and `tts.google_generative_ai` still receive stripped text, and that `google_translate`, `tts.google_translate`, `Google Translate` and `tts.google_en_com` all resolve as supporting. 

### Tested end-to-end on a real Home Assistant

Beyond the unit-level checks above, I deployed this branch to my own Home Assistant (HA OS) running `v1.3.0-beta1` and exercised it through `chime_tts.say` on real media players. Vowelled Hebrew now comes out correctly via Google Translate, and the rest of the integration behaves as before.
